### PR TITLE
docs(readme): add comprehensive .env configuration reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,110 @@ Get an API key at [console.anthropic.com](https://console.anthropic.com).
 
 ---
 
+## Environment Configuration (.env)
+
+VoiceVault uses a `.env` file for all configuration. To get started, copy the example file and edit it:
+
+```bash
+cp .env.example .env
+```
+
+> **Note:** The `scripts/setup_dev.sh` script creates this file for you automatically during setup.
+
+Below is a complete reference of all available settings:
+
+### LLM Provider
+
+| Variable | Description | Options | Default |
+|---|---|---|---|
+| `LLM_PROVIDER` | Which language model to use | `ollama`, `claude` | `ollama` |
+
+### Claude API (when `LLM_PROVIDER=claude`)
+
+| Variable | Description | Default |
+|---|---|---|
+| `CLAUDE_API_KEY` | Your Anthropic API key | *(empty)* |
+| `CLAUDE_MODEL` | Claude model to use | `claude-sonnet-4-20250514` |
+
+### Ollama (when `LLM_PROVIDER=ollama`)
+
+| Variable | Description | Default |
+|---|---|---|
+| `OLLAMA_BASE_URL` | Ollama server URL | `http://localhost:11434` |
+| `OLLAMA_MODEL` | Ollama model name | `llama3.2` |
+
+> **Docker note:** When running via Docker Compose, `OLLAMA_BASE_URL` is automatically overridden to `http://ollama:11434`.
+
+### Whisper (Speech-to-Text)
+
+| Variable | Description | Options / Default |
+|---|---|---|
+| `WHISPER_PROVIDER` | STT engine | `local` (default), `api` |
+| `WHISPER_MODEL` | Whisper model size | `base` (default), `small`, `medium`, `large-v3`, `turbo` |
+| `WHISPER_API_KEY` | OpenAI API key (only if `WHISPER_PROVIDER=api`) | *(empty)* |
+| `WHISPER_DEFAULT_LANGUAGE` | Default transcription language | *(empty = auto-detect)*; `ko`, `en`, `ja`, etc. |
+
+### RAG & Embeddings
+
+| Variable | Description | Default |
+|---|---|---|
+| `EMBEDDING_PROVIDER` | Embedding engine | `local` (sentence-transformers) or `ollama` |
+| `EMBEDDING_MODEL` | sentence-transformers model (when `local`) | `all-MiniLM-L6-v2` |
+| `OLLAMA_EMBEDDING_MODEL` | Ollama embedding model (when `ollama`) | `nomic-embed-text` |
+| `CHROMA_PERSIST_DIR` | ChromaDB storage path | `data/chroma_db` |
+| `RAG_TOP_K` | Number of search results to retrieve | `5` |
+| `RAG_MIN_SIMILARITY` | Minimum similarity score for results | `0.3` |
+
+### Obsidian Export
+
+| Variable | Description | Default |
+|---|---|---|
+| `OBSIDIAN_VAULT_PATH` | Direct export path to your Obsidian vault | *(empty)* |
+| `OBSIDIAN_EXPORT_FOLDER` | Subfolder within vault for exports | `VoiceVault` |
+| `OBSIDIAN_FRONTMATTER` | Include YAML frontmatter in exports | `true` |
+| `OBSIDIAN_WIKILINKS` | Use `[[wikilinks]]` for related notes | `true` |
+
+### Application
+
+| Variable | Description | Default |
+|---|---|---|
+| `APP_HOST` | Server bind address | `0.0.0.0` |
+| `APP_PORT` | Backend API port | `8000` |
+| `LOG_LEVEL` | Logging verbosity | `INFO` |
+
+### Storage
+
+| Variable | Description | Default |
+|---|---|---|
+| `DATABASE_URL` | SQLite database path | `sqlite:///data/voicevault.db` |
+| `RECORDINGS_DIR` | Audio recordings directory | `data/recordings` |
+| `EXPORTS_DIR` | Markdown exports directory | `data/exports` |
+
+<details>
+<summary><strong>Minimal .env example (Ollama, all defaults)</strong></summary>
+
+```env
+LLM_PROVIDER=ollama
+```
+
+That's it — all other values use sensible defaults. Just make sure Ollama is running with `ollama serve`.
+</details>
+
+<details>
+<summary><strong>Full .env example (Claude + Korean + Obsidian)</strong></summary>
+
+```env
+LLM_PROVIDER=claude
+CLAUDE_API_KEY=sk-ant-xxxxx
+WHISPER_MODEL=medium
+WHISPER_DEFAULT_LANGUAGE=ko
+OBSIDIAN_VAULT_PATH=/Users/you/Documents/ObsidianVault
+OBSIDIAN_EXPORT_FOLDER=VoiceVault
+```
+</details>
+
+---
+
 ## Example: A Day with VoiceVault
 
 Here's what a typical day looks like:


### PR DESCRIPTION
The README only had a brief mention of .env for Claude API key setup. Added a full "Environment Configuration (.env)" section covering all settings: LLM provider, Whisper STT, RAG & embeddings, Obsidian export, application, and storage options with defaults and examples.