### PR TITLE
chore(config): update Docker/CI/dev scripts for backend/ directory (closes #75)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
 
   # Python (pip) — keep Python dependencies up to date
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/backend"
     schedule:
       interval: "weekly"
     commit-message:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
   lint:
     name: Lint & Format Check
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
 
     steps:
       - name: Checkout code
@@ -46,6 +49,9 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
 
     strategy:
       matrix:
@@ -65,6 +71,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install system dependencies
+        working-directory: .
         run: |
           sudo apt-get update
           sudo apt-get install -y libsndfile1 ffmpeg
@@ -82,6 +89,7 @@ jobs:
 
       - name: Run tests
         env:
+          PYTHONPATH: ${{ github.workspace }}/backend
           ENVIRONMENT: test
           LLM_PROVIDER: ollama
           WHISPER_PROVIDER: local
@@ -95,7 +103,7 @@ jobs:
         uses: codecov/codecov-action@v4
         if: matrix.python-version == '3.12'
         with:
-          file: ./coverage.xml
+          file: ./backend/coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
@@ -106,6 +114,9 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
 
     steps:
       - name: Checkout code
@@ -126,7 +137,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: bandit-security-report
-          path: bandit-report.json
+          path: backend/bandit-report.json
           retention-days: 30
 
   # ===========================================================================

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: build up down logs health seed clean up-ollama
+.PHONY: build up down logs health seed clean up-ollama dev-api dev-ui lint test
+
+# ── Docker ──────────────────────────────────────────
 
 # Build all Docker images
 build:
@@ -29,8 +31,29 @@ health:
 
 # Run demo data seeder inside the API container
 seed:
-	docker compose exec api python scripts/seed_demo_data.py
+	docker compose exec api python backend/scripts/seed_demo_data.py
 
 # Stop all services and remove volumes
 clean:
 	docker compose --profile ollama down -v
+
+# ── Local Development ───────────────────────────────
+
+# Start backend API locally (PYTHONPATH=backend)
+dev-api:
+	PYTHONPATH=backend uvicorn src.api.app:app --reload --port 8000
+
+# Start Streamlit UI locally
+dev-ui:
+	streamlit run src/ui/app.py
+
+# ── Quality ─────────────────────────────────────────
+
+# Lint & format check (backend code)
+lint:
+	ruff check backend/src/ backend/tests/
+	ruff format --check backend/src/ backend/tests/
+
+# Run tests (from backend/ directory)
+test:
+	cd backend && pytest tests/ -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "8000:8000"
     env_file: .env
     environment:
+      - PYTHONPATH=/app/backend
       - DATABASE_URL=${DATABASE_URL:-sqlite+aiosqlite:///./data/voicevault.db}
       - LLM_PROVIDER=${LLM_PROVIDER:-ollama}
       - OLLAMA_BASE_URL=http://ollama:11434
@@ -33,7 +34,8 @@ services:
       - EXPORTS_DIR=${EXPORTS_DIR:-data/exports}
     volumes:
       - ./data:/app/data
-      - ./src:/app/src:ro
+      - ./backend/src:/app/backend/src:ro
+      - ./templates:/app/templates:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 15s
@@ -60,7 +62,7 @@ services:
       - STREAMLIT_SERVER_HEADLESS=true
       - STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
     volumes:
-      - ./src:/app/src:ro
+      - ./src/ui:/app/src/ui:ro
     depends_on:
       api:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- **Dockerfile**: Updated `COPY` paths to `backend/`, set `PYTHONPATH=/app/backend`, copy `src/ui/` separately for Streamlit
- **docker-compose.yml**: Added `PYTHONPATH` env var, updated volume mounts (`backend/src`, `templates`, `src/ui`), fixed dev mount paths
- **Makefile**: Added `dev-api`, `dev-ui`, `lint`, `test` targets; updated `seed` command path
- **.github/workflows/ci.yml**: Set `working-directory: backend` for lint/test/security jobs, added `PYTHONPATH` to test env, fixed artifact paths
- **.github/dependabot.yml**: Changed pip `directory` from `/` to `/backend`
- **backend/scripts/setup_dev.sh**: Uses `SCRIPT_DIR`/`REPO_ROOT`/`BACKEND_DIR` for portable path resolution; updated next-steps instructions

## Context
PR #98 moved all Python backend code to `backend/`. This PR updates all build/CI/dev tooling to match the new directory structure.

## Test plan
- [ ] `docker compose config` passes (validated locally ✅)
- [ ] All `Dockerfile` COPY source paths exist (validated locally ✅)
- [ ] `docker compose build && docker compose up` boots API → `/health` returns 200
- [ ] CI lint/test/security jobs run from `backend/` working directory
- [ ] `make lint` and `make test` work locally
- [ ] `bash backend/scripts/setup_dev.sh` completes successfully

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)