### PR TITLE
feat(frontend): typed env config with build-time validation

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,14 @@
+# VoiceVault Frontend — Environment Variables
+# Copy this file to .env.local and adjust values for your setup.
+#
+# Next.js loads env files in this order (later wins):
+#   .env → .env.local → .env.development → .env.development.local
+#
+# NEXT_PUBLIC_ prefix exposes the variable to the browser bundle.
+
+# ── Backend API ──────────────────────────────────────────────────
+# Base URL for REST API calls (no trailing slash)
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api/v1
+
+# WebSocket URL for real-time transcription (no trailing slash)
+NEXT_PUBLIC_WS_URL=ws://localhost:8000

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -30,8 +30,11 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
-.env*
+# env files — .env.example is tracked; secrets stay local
+.env*.local
+.env.development
+.env.production
+!.env.example
 
 # vercel
 .vercel

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,47 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# VoiceVault Frontend
 
-## Getting Started
+Next.js 16 + TypeScript + Tailwind CSS frontend for VoiceVault.
 
-First, run the development server:
+## Quick Start
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+pnpm install
+cp .env.example .env.local   # configure backend URLs
+pnpm dev                      # → http://localhost:3000
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Environment Variables
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+Copy `.env.example` to `.env.local` and adjust for your environment.
+`.env.local` is gitignored — it never gets committed.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NEXT_PUBLIC_API_BASE_URL` | `http://localhost:8000/api/v1` | REST API base URL (no trailing slash) |
+| `NEXT_PUBLIC_WS_URL` | `ws://localhost:8000` | WebSocket base URL (no trailing slash) |
 
-## Learn More
+### How It Works
 
-To learn more about Next.js, take a look at the following resources:
+- `src/lib/env.ts` validates all required env vars at build/startup time
+- Missing vars → build fails with a clear error message pointing to `.env.example`
+- Trailing slashes are auto-stripped to prevent double-slash URL bugs
+- `src/lib/api.ts` and WebSocket helpers import URLs from `env.ts`
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+### Environment Switching
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+| Environment | File | Example |
+|-------------|------|---------|
+| Local dev | `.env.local` | `http://localhost:8000/api/v1` |
+| Staging | `.env.production` (or Vercel env) | `https://staging-api.voicevault.dev/api/v1` |
+| Production | Vercel / Docker env vars | `https://api.voicevault.dev/api/v1` |
 
-## Deploy on Vercel
+## Scripts
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+pnpm dev            # Development server
+pnpm build          # Production build
+pnpm start          # Start production server
+pnpm lint           # ESLint
+pnpm format         # Prettier
+pnpm type-check     # TypeScript type checking
+```

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,4 @@
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000/api/v1";
+import { API_BASE_URL } from "@/lib/env";
 
 export async function apiFetch<T>(
   path: string,

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,0 +1,35 @@
+/**
+ * Typed environment variable access with build-time validation.
+ *
+ * NEXT_PUBLIC_* vars are inlined at build time — if a required var is
+ * missing, the build should fail fast with a clear error message rather
+ * than producing a broken bundle that silently hits the wrong URL.
+ */
+
+function required(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(
+      `Missing required environment variable: ${key}\n` +
+        `Copy frontend/.env.example to frontend/.env.local and set it.`,
+    );
+  }
+  return value;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+/** REST API base URL (e.g. "http://localhost:8000/api/v1") */
+export const API_BASE_URL = stripTrailingSlash(
+  required("NEXT_PUBLIC_API_BASE_URL"),
+);
+
+/** WebSocket base URL (e.g. "ws://localhost:8000") */
+export const WS_URL = stripTrailingSlash(required("NEXT_PUBLIC_WS_URL"));
+
+/** WebSocket endpoint for real-time transcription */
+export function wsTranscribeUrl(recordingId: number): string {
+  return `${WS_URL}/ws/transcribe?recording_id=${recordingId}`;
+}


### PR DESCRIPTION
## Summary
- Add `frontend/.env.example` with `NEXT_PUBLIC_API_BASE_URL` and `NEXT_PUBLIC_WS_URL`
- Add `frontend/src/lib/env.ts` — typed, validated env access with `stripTrailingSlash` and fail-fast on missing vars
- Update `frontend/src/lib/api.ts` to import from `env.ts` instead of inline `process.env` with silent fallback
- Update `frontend/.gitignore` to track `.env.example` while keeping `.env.local` gitignored
- Replace boilerplate README with VoiceVault-specific docs covering env strategy and environment switching

Closes #78

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm build` passes (Next.js picks up `.env.local`)
- [ ] Verify: remove `.env.local` → build fails with clear error message
- [ ] Verify: set `NEXT_PUBLIC_API_BASE_URL` with trailing slash → slash is stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)