### PR TITLE
feat(frontend): add typed API client + error standardization (closes #79)

### DIFF
--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,0 +1,119 @@
+import { API_BASE_URL } from "@/lib/env";
+import type { ApiErrorBody } from "@/types/api";
+
+// ---------------------------------------------------------------------------
+// ApiError
+// ---------------------------------------------------------------------------
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly details: string | null;
+
+  constructor(status: number, code: string, message: string, details?: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.code = code;
+    this.details = details ?? null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function parseErrorBody(res: Response): Promise<ApiError> {
+  try {
+    const body: ApiErrorBody = await res.json();
+    return new ApiError(res.status, body.code, body.detail);
+  } catch {
+    return new ApiError(
+      res.status,
+      "UNKNOWN_ERROR",
+      `${res.status} ${res.statusText}`,
+    );
+  }
+}
+
+type RequestOptions = Omit<RequestInit, "method" | "body"> & {
+  timeout?: number;
+};
+
+async function request<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  opts: RequestOptions = {},
+): Promise<T> {
+  const { timeout = DEFAULT_TIMEOUT_MS, headers: extraHeaders, ...rest } = opts;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  const headers: HeadersInit = { ...extraHeaders };
+  if (body !== undefined) {
+    (headers as Record<string, string>)["Content-Type"] = "application/json";
+  }
+
+  try {
+    const res = await fetch(`${API_BASE_URL}${path}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+      ...rest,
+    });
+
+    if (!res.ok) {
+      throw await parseErrorBody(res);
+    }
+
+    // 204 No Content
+    if (res.status === 204) {
+      return undefined as T;
+    }
+
+    return (await res.json()) as T;
+  } catch (err) {
+    if (err instanceof ApiError) throw err;
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new ApiError(0, "TIMEOUT", `Request timed out after ${timeout}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export const apiClient = {
+  get<T>(path: string, opts?: RequestOptions): Promise<T> {
+    return request<T>("GET", path, undefined, opts);
+  },
+
+  post<T>(path: string, body?: unknown, opts?: RequestOptions): Promise<T> {
+    return request<T>("POST", path, body, opts);
+  },
+
+  put<T>(path: string, body?: unknown, opts?: RequestOptions): Promise<T> {
+    return request<T>("PUT", path, body, opts);
+  },
+
+  patch<T>(path: string, body?: unknown, opts?: RequestOptions): Promise<T> {
+    return request<T>("PATCH", path, body, opts);
+  },
+
+  delete<T>(path: string, opts?: RequestOptions): Promise<T> {
+    return request<T>("DELETE", path, undefined, opts);
+  },
+} as const;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,20 +1,6 @@
-import { API_BASE_URL } from "@/lib/env";
-
-export async function apiFetch<T>(
-  path: string,
-  init?: RequestInit,
-): Promise<T> {
-  const res = await fetch(`${API_BASE_URL}${path}`, {
-    headers: { "Content-Type": "application/json", ...init?.headers },
-    ...init,
-  });
-
-  if (!res.ok) {
-    const body = await res.json().catch(() => null);
-    throw new Error(
-      body?.detail ?? `API error: ${res.status} ${res.statusText}`,
-    );
-  }
-
-  return res.json() as Promise<T>;
-}
+/**
+ * @deprecated — Use {@link @/lib/api-client} for the fetch wrapper
+ * or {@link @/lib/api/*} for endpoint-specific modules.
+ */
+export { apiClient } from "./api-client";
+export { ApiError } from "./api-client";

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,0 +1,2 @@
+export { recordingsApi } from "./recordings";
+export { summariesApi } from "./summaries";

--- a/frontend/src/lib/api/recordings.ts
+++ b/frontend/src/lib/api/recordings.ts
@@ -1,0 +1,57 @@
+import { apiClient } from "@/lib/api-client";
+import type {
+  RecordingResponse,
+  RecordingCreateRequest,
+  DeleteRecordingResponse,
+  ProcessRecordingResponse,
+  SyncResponse,
+  ConsistencyResponse,
+  ClassificationResponse,
+  ObsidianExportRequest,
+  ObsidianExportResponse,
+} from "@/types/api";
+
+export const recordingsApi = {
+  list(): Promise<RecordingResponse[]> {
+    return apiClient.get("/recordings");
+  },
+
+  get(id: number): Promise<RecordingResponse> {
+    return apiClient.get(`/recordings/${id}`);
+  },
+
+  create(body?: RecordingCreateRequest): Promise<RecordingResponse> {
+    return apiClient.post("/recordings", body);
+  },
+
+  stop(id: number): Promise<RecordingResponse> {
+    return apiClient.patch(`/recordings/${id}/stop`);
+  },
+
+  delete(id: number): Promise<DeleteRecordingResponse> {
+    return apiClient.delete(`/recordings/${id}`);
+  },
+
+  process(id: number): Promise<ProcessRecordingResponse> {
+    return apiClient.post(`/recordings/${id}/process`);
+  },
+
+  sync(): Promise<SyncResponse> {
+    return apiClient.post("/recordings/sync");
+  },
+
+  consistency(): Promise<ConsistencyResponse> {
+    return apiClient.get("/recordings/consistency");
+  },
+
+  classifications(id: number): Promise<ClassificationResponse[]> {
+    return apiClient.get(`/recordings/${id}/classifications`);
+  },
+
+  export(
+    id: number,
+    body?: ObsidianExportRequest,
+  ): Promise<ObsidianExportResponse> {
+    return apiClient.post(`/recordings/${id}/export`, body);
+  },
+} as const;

--- a/frontend/src/lib/api/summaries.ts
+++ b/frontend/src/lib/api/summaries.ts
@@ -1,0 +1,24 @@
+import { apiClient } from "@/lib/api-client";
+import type {
+  SummaryResponse,
+  HourSummaryResponse,
+  ExtractRangeRequest,
+  ExtractRangeResponse,
+} from "@/types/api";
+
+export const summariesApi = {
+  list(recordingId: number): Promise<SummaryResponse[]> {
+    return apiClient.get(`/recordings/${recordingId}/summaries`);
+  },
+
+  hourSummaries(recordingId: number): Promise<HourSummaryResponse[]> {
+    return apiClient.get(`/recordings/${recordingId}/hour-summaries`);
+  },
+
+  extractRange(
+    recordingId: number,
+    body: ExtractRangeRequest,
+  ): Promise<ExtractRangeResponse> {
+    return apiClient.post(`/recordings/${recordingId}/extract`, body);
+  },
+} as const;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,256 @@
+/**
+ * API response types matching backend Pydantic models.
+ *
+ * Field names use snake_case to match the JSON wire format from FastAPI.
+ * Keep in sync with backend/src/core/models.py.
+ */
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export type RecordingStatus =
+  | "active"
+  | "processing"
+  | "completed"
+  | "failed"
+  | "imported";
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+/** Standard error body returned by the backend error_handler middleware. */
+export interface ApiErrorBody {
+  detail: string;
+  code: string;
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+export interface HealthResponse {
+  status: string;
+  version: string;
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// Recording
+// ---------------------------------------------------------------------------
+
+export interface RecordingResponse {
+  id: number;
+  title: string | null;
+  context: string | null;
+  status: RecordingStatus;
+  started_at: string;
+  ended_at: string | null;
+  total_minutes: number;
+  audio_path: string | null;
+}
+
+export interface RecordingCreateRequest {
+  title?: string;
+  context?: string;
+}
+
+export interface DeleteRecordingResponse {
+  recording_id: number;
+  db_deleted: boolean;
+  audio_deleted: boolean;
+  exports_deleted: number;
+  vectors_deleted: number;
+}
+
+export interface ProcessRecordingResponse {
+  recording_id: number;
+  status: string;
+  total_minutes: number;
+  transcripts_created: number;
+  summaries_created: number;
+  embeddings_created: number;
+}
+
+export interface SyncResponse {
+  scanned: number;
+  new_imports: number;
+  already_exists: number;
+  errors: string[];
+}
+
+export interface OrphanRecord {
+  recording_id: number;
+  audio_path: string | null;
+  reason: string;
+}
+
+export interface OrphanFile {
+  file_path: string;
+  reason: string;
+}
+
+export interface ConsistencyResponse {
+  total_db_records: number;
+  total_fs_files: number;
+  orphan_records: OrphanRecord[];
+  orphan_files: OrphanFile[];
+  healthy_count: number;
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+export interface TranscriptionCorrection {
+  original: string;
+  corrected: string;
+  reason: string;
+}
+
+export interface SummaryResponse {
+  id: number;
+  recording_id: number;
+  minute_index: number;
+  summary_text: string;
+  keywords: string[];
+  confidence: number;
+  corrections: TranscriptionCorrection[];
+  created_at: string;
+}
+
+export interface HourSummaryResponse {
+  id: number;
+  recording_id: number;
+  hour_index: number;
+  summary_text: string;
+  keywords: string[];
+  topic_segments: Record<string, unknown>[];
+  token_count: number;
+  model_used: string;
+  created_at: string;
+}
+
+export interface ExtractRangeRequest {
+  start_minute: number;
+  end_minute: number;
+}
+
+export interface ExtractRangeResponse {
+  recording_id: number;
+  start_minute: number;
+  end_minute: number;
+  summary_text: string;
+  keywords: string[];
+  included_minutes: number[];
+  source_count: number;
+  model_used: string;
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+export interface ClassificationResponse {
+  id: number;
+  recording_id: number;
+  template_name: string;
+  start_minute: number;
+  end_minute: number;
+  confidence: number;
+  result: Record<string, unknown>;
+  export_path: string | null;
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Template
+// ---------------------------------------------------------------------------
+
+export interface TemplateResponse {
+  id: number;
+  name: string;
+  display_name: string;
+  triggers: string[];
+  output_format: string;
+  fields: Record<string, unknown>[];
+  icon: string;
+  priority: number;
+  is_default: boolean;
+  is_active: boolean;
+  created_at: string;
+}
+
+export interface TemplateCreateRequest {
+  name: string;
+  display_name: string;
+  triggers: string[];
+  output_format?: string;
+  fields: Record<string, unknown>[];
+  icon: string;
+  priority: number;
+}
+
+export interface TemplateUpdateRequest {
+  display_name?: string;
+  triggers?: string[];
+  output_format?: string;
+  fields?: Record<string, unknown>[];
+  icon?: string;
+  priority?: number;
+  is_active?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// RAG
+// ---------------------------------------------------------------------------
+
+export interface RAGQueryRequest {
+  query: string;
+  top_k?: number;
+  min_similarity?: number;
+  date_from?: string;
+  date_to?: string;
+  category?: string;
+  keywords?: string[];
+}
+
+export interface RAGSource {
+  recording_id: number;
+  minute_index: number;
+  summary_text: string;
+  similarity: number;
+  date: string;
+  category: string;
+}
+
+export interface RAGQueryResponse {
+  answer: string;
+  sources: RAGSource[];
+  model_used: string;
+  query_time_ms: number;
+}
+
+export interface ReindexResponse {
+  reindexed: number;
+  errors: number;
+  total_in_store: number;
+}
+
+// ---------------------------------------------------------------------------
+// Export (Obsidian)
+// ---------------------------------------------------------------------------
+
+export interface ObsidianExportRequest {
+  format?: string;
+  include_transcript?: boolean;
+  vault_path?: string;
+}
+
+export interface ObsidianExportResponse {
+  file_path: string;
+  markdown_content: string;
+  frontmatter: Record<string, unknown>;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,19 +1,24 @@
-/** Shared TypeScript types for VoiceVault frontend. */
+/**
+ * Shared TypeScript types for VoiceVault frontend.
+ *
+ * Re-exports API types for convenience.
+ * Domain-specific types that don't come from the API can live here.
+ */
 
-export interface Recording {
-  id: number;
-  started_at: string;
-  ended_at: string | null;
-  status: "recording" | "completed" | "error";
-  total_minutes: number;
-}
+export type {
+  RecordingStatus,
+  RecordingResponse,
+  RecordingCreateRequest,
+  SummaryResponse,
+  HourSummaryResponse,
+  ClassificationResponse,
+  TemplateResponse,
+  RAGQueryRequest,
+  RAGQueryResponse,
+  RAGSource,
+  ObsidianExportResponse,
+} from "./api";
 
-export interface Summary {
-  id: number;
-  recording_id: number;
-  minute_index: number;
-  summary_text: string;
-  keywords: string[];
-  speakers: string[];
-  confidence: number;
-}
+// Legacy aliases — keep until all consumers migrate to @/types/api
+export type Recording = import("./api").RecordingResponse;
+export type Summary = import("./api").SummaryResponse;


### PR DESCRIPTION
## Summary
- **`ApiError` class** with `status`, `code`, `details` fields for structured error handling
- **`apiClient`** typed fetch wrapper (`get`, `post`, `put`, `patch`, `delete`) with configurable timeout (default 30s) and automatic JSON parsing
- **`@/types/api.ts`** — 25+ TypeScript interfaces matching all backend Pydantic response models (`RecordingResponse`, `SummaryResponse`, `RAGQueryResponse`, etc.)
- **`@/lib/api/recordings.ts`** — endpoint module for all `/recordings/*` routes (list, get, create, stop, delete, process, sync, export, etc.)
- **`@/lib/api/summaries.ts`** — endpoint module for summary/hour-summary/extract routes
- **`@/lib/api/index.ts`** — barrel re-export for clean imports
- Legacy `api.ts` updated to re-export from new module; `types/index.ts` updated with backward-compatible aliases

## Test plan
- [x] `pnpm type-check` passes (zero errors)
- [x] `pnpm build` passes (Next.js production build succeeds)
- [ ] Manual: verify `recordingsApi.list()` calls correct URL in browser devtools
- [ ] Manual: verify `ApiError` thrown on 4xx/5xx responses with correct fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)