### PR TITLE
feat(frontend): add microphone permission and device selection (closes #80)

### DIFF
--- a/frontend/src/app/recording/page.tsx
+++ b/frontend/src/app/recording/page.tsx
@@ -1,8 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import { useMicrophonePermission } from "@/hooks/use-microphone-permission";
+import { useMediaDevices } from "@/hooks/use-media-devices";
+import { useRecordingStore } from "@/stores/recording";
+import { PermissionGate } from "@/components/recording/PermissionGate";
+import { DeviceSelector } from "@/components/recording/DeviceSelector";
+
 export default function RecordingPage() {
+  const { status, request } = useMicrophonePermission();
+  const { devices, selectedDeviceId, selectDevice, refresh } = useMediaDevices(
+    status === "granted",
+  );
+
+  const setSelectedDeviceId = useRecordingStore((s) => s.setSelectedDeviceId);
+
+  // Sync local device selection to global store
+  useEffect(() => {
+    setSelectedDeviceId(selectedDeviceId);
+  }, [selectedDeviceId, setSelectedDeviceId]);
+
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-8">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <h1 className="text-3xl font-bold">Recording</h1>
-      <p className="mt-4 text-zinc-500">Recording page — coming soon.</p>
+
+      <PermissionGate status={status} onRequest={request}>
+        <div className="w-full max-w-md space-y-6">
+          <DeviceSelector
+            devices={devices}
+            selectedDeviceId={selectedDeviceId}
+            onSelect={selectDevice}
+            onRefresh={refresh}
+          />
+          <p className="text-center text-sm text-zinc-500">
+            Microphone ready. Recording controls coming soon.
+          </p>
+        </div>
+      </PermissionGate>
     </div>
   );
 }

--- a/frontend/src/components/recording/DeviceSelector.tsx
+++ b/frontend/src/components/recording/DeviceSelector.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import type { AudioDevice } from "@/hooks/use-media-devices";
+import { cn } from "@/lib/cn";
+
+interface DeviceSelectorProps {
+  devices: AudioDevice[];
+  selectedDeviceId: string | null;
+  onSelect: (deviceId: string) => void;
+  onRefresh: () => void;
+  className?: string;
+}
+
+export function DeviceSelector({
+  devices,
+  selectedDeviceId,
+  onSelect,
+  onRefresh,
+  className,
+}: DeviceSelectorProps) {
+  if (devices.length === 0) {
+    return (
+      <div className={cn("flex items-center gap-2 text-sm text-zinc-500", className)}>
+        <MicOffIcon />
+        <span>No audio devices found.</span>
+        <button
+          type="button"
+          onClick={onRefresh}
+          className="text-zinc-900 underline underline-offset-2 hover:text-zinc-700 dark:text-zinc-300 dark:hover:text-zinc-100"
+        >
+          Refresh
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex items-center gap-3", className)}>
+      <label htmlFor="device-select" className="flex items-center gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <MicIcon />
+        <span>Microphone</span>
+      </label>
+      <select
+        id="device-select"
+        value={selectedDeviceId ?? ""}
+        onChange={(e) => onSelect(e.target.value)}
+        className="min-w-0 flex-1 rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 transition-colors focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-400 focus:ring-offset-2 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+      >
+        {devices.map((device) => (
+          <option key={device.deviceId} value={device.deviceId}>
+            {device.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function MicIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <line x1="12" x2="12" y1="19" y2="22" />
+    </svg>
+  );
+}
+
+function MicOffIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <line x1="2" x2="22" y1="2" y2="22" />
+      <path d="M18.89 13.23A7.12 7.12 0 0 0 19 12v-2" />
+      <path d="M5 10v2a7 7 0 0 0 12 5.29" />
+      <path d="M15 9.34V5a3 3 0 0 0-5.68-1.33" />
+      <path d="M9 9v3a3 3 0 0 0 5.12 2.12" />
+      <line x1="12" x2="12" y1="19" y2="22" />
+    </svg>
+  );
+}

--- a/frontend/src/components/recording/PermissionGate.tsx
+++ b/frontend/src/components/recording/PermissionGate.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { PermissionStatus } from "@/hooks/use-microphone-permission";
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+
+interface PermissionGateProps {
+  status: PermissionStatus;
+  onRequest: () => void;
+  children: ReactNode;
+}
+
+export function PermissionGate({ status, onRequest, children }: PermissionGateProps) {
+  if (status === "granted") {
+    return <>{children}</>;
+  }
+
+  if (status === "unsupported") {
+    return (
+      <Card className="mx-auto max-w-md text-center">
+        <CardHeader>
+          <CardTitle>Browser Not Supported</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p>
+            Your browser does not support audio recording.
+            Please use a modern browser such as Chrome, Firefox, or Edge.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (status === "denied") {
+    return (
+      <Card className="mx-auto max-w-md text-center">
+        <CardHeader>
+          <CardTitle>Microphone Access Denied</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p>
+            VoiceVault needs microphone access to record audio. Permission was denied by your browser.
+          </p>
+          <p className="text-xs text-zinc-400">
+            To fix this, click the lock/site-settings icon in your browser&apos;s address bar
+            and allow microphone access, then reload the page.
+          </p>
+          <Button variant="secondary" onClick={onRequest}>
+            Try Again
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // status === "prompt" — initial state
+  return (
+    <Card className="mx-auto max-w-md text-center">
+      <CardHeader>
+        <CardTitle>Microphone Permission Required</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p>
+          VoiceVault needs access to your microphone to record audio.
+          Click the button below to grant permission.
+        </p>
+        <Button onClick={onRequest}>
+          Allow Microphone Access
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/hooks/use-media-devices.ts
+++ b/frontend/src/hooks/use-media-devices.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface AudioDevice {
+  deviceId: string;
+  label: string;
+}
+
+interface UseMediaDevicesReturn {
+  devices: AudioDevice[];
+  selectedDeviceId: string | null;
+  selectDevice: (deviceId: string) => void;
+  refresh: () => Promise<void>;
+}
+
+export function useMediaDevices(permissionGranted: boolean): UseMediaDevicesReturn {
+  const [devices, setDevices] = useState<AudioDevice[]>([]);
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+
+  const enumerate = useCallback(async () => {
+    if (!navigator.mediaDevices?.enumerateDevices) return;
+
+    const allDevices = await navigator.mediaDevices.enumerateDevices();
+    const audioInputs = allDevices
+      .filter((d) => d.kind === "audioinput")
+      .map((d, i) => ({
+        deviceId: d.deviceId,
+        label: d.label || `Microphone ${i + 1}`,
+      }));
+
+    setDevices(audioInputs);
+
+    // Auto-select first device if nothing selected or previous selection is gone
+    setSelectedDeviceId((prev) => {
+      if (prev && audioInputs.some((d) => d.deviceId === prev)) return prev;
+      return audioInputs[0]?.deviceId ?? null;
+    });
+  }, []);
+
+  // Enumerate when permission is granted
+  useEffect(() => {
+    if (permissionGranted) {
+      enumerate();
+    }
+  }, [permissionGranted, enumerate]);
+
+  // Listen for device hot-plug/unplug
+  useEffect(() => {
+    if (!permissionGranted) return;
+
+    const handler = () => enumerate();
+    navigator.mediaDevices.addEventListener("devicechange", handler);
+    return () => navigator.mediaDevices.removeEventListener("devicechange", handler);
+  }, [permissionGranted, enumerate]);
+
+  return {
+    devices,
+    selectedDeviceId,
+    selectDevice: setSelectedDeviceId,
+    refresh: enumerate,
+  };
+}

--- a/frontend/src/stores/recording.ts
+++ b/frontend/src/stores/recording.ts
@@ -3,13 +3,17 @@ import { create } from "zustand";
 interface RecordingState {
   isRecording: boolean;
   currentRecordingId: number | null;
+  selectedDeviceId: string | null;
   start: (id: number) => void;
   stop: () => void;
+  setSelectedDeviceId: (deviceId: string | null) => void;
 }
 
 export const useRecordingStore = create<RecordingState>((set) => ({
   isRecording: false,
   currentRecordingId: null,
+  selectedDeviceId: null,
   start: (id) => set({ isRecording: true, currentRecordingId: id }),
   stop: () => set({ isRecording: false, currentRecordingId: null }),
+  setSelectedDeviceId: (deviceId) => set({ selectedDeviceId: deviceId }),
 }));


### PR DESCRIPTION
## Summary
- Add `useMicrophonePermission` hook — queries/requests browser mic permission via `navigator.permissions` + `getUserMedia`, tracks state reactively
- Add `useMediaDevices` hook — enumerates audio input devices after permission is granted, handles hot-plug via `devicechange` event
- Add `PermissionGate` component — render-gate that shows appropriate UI for each permission state (prompt/granted/denied/unsupported)
- Add `DeviceSelector` component — dropdown to pick audio input device with refresh + no-devices fallback
- Update recording page to compose all components and sync selected device to Zustand store
- Extend `useRecordingStore` with `selectedDeviceId` for downstream recording pipeline use

## Test plan
- [ ] Visit `/recording` page — should show "Allow Microphone Access" prompt card
- [ ] Click allow → browser permission dialog appears, granting shows device dropdown
- [ ] Device dropdown lists all connected audio inputs with correct labels
- [ ] Plugging/unplugging a USB mic updates the device list live
- [ ] Denying permission shows "Microphone Access Denied" card with instructions
- [ ] Opening in unsupported browser (e.g. older WebView) shows "Browser Not Supported"
- [ ] `pnpm build` passes
- [ ] `pnpm type-check` passes

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)