### PR TITLE
feat(frontend): add Web Audio API capture + PCM16/16kHz encoding (closes #81)

### DIFF
--- a/frontend/public/audio-capture-processor.js
+++ b/frontend/public/audio-capture-processor.js
@@ -1,0 +1,41 @@
+/**
+ * AudioWorklet processor for low-latency audio capture.
+ *
+ * Runs on the audio rendering thread. Collects Float32 samples from
+ * the microphone and posts them to the main thread via MessagePort.
+ *
+ * NOTE: This file is served as a static asset (public/) because
+ * AudioWorklet processors cannot be bundled — the browser loads them
+ * via audioContext.audioWorklet.addModule(url).
+ */
+
+class AudioCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._stopped = false;
+    this.port.onmessage = (event) => {
+      if (event.data === "stop") {
+        this._stopped = true;
+      }
+    };
+  }
+
+  /**
+   * Called by the audio engine with 128 frames per invocation.
+   * We copy channel 0 (mono) and post it to the main thread.
+   */
+  process(inputs) {
+    if (this._stopped) return false;
+
+    const input = inputs[0];
+    if (!input || !input[0] || input[0].length === 0) return true;
+
+    // Copy channel 0 — postMessage transfers ownership, so we need a copy
+    const samples = new Float32Array(input[0]);
+    this.port.postMessage(samples, [samples.buffer]);
+
+    return true;
+  }
+}
+
+registerProcessor("audio-capture-processor", AudioCaptureProcessor);

--- a/frontend/src/hooks/useAudioCapture.ts
+++ b/frontend/src/hooks/useAudioCapture.ts
@@ -1,0 +1,138 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRecordingStore } from "@/stores/recording";
+import {
+  createCaptureNodes,
+  type CaptureNodes,
+} from "@/lib/audio/audio-worklet-processor";
+import { encodePcm16Chunk, TARGET_SAMPLE_RATE } from "@/lib/audio/pcm-encoder";
+
+/** Default interval (ms) between flushing buffered audio as PCM16 chunks. */
+const DEFAULT_FLUSH_INTERVAL_MS = 250;
+
+export interface UseAudioCaptureOptions {
+  /** Called with a PCM16 ArrayBuffer chunk at 16 kHz mono, ready for WebSocket. */
+  onChunk: (pcm16: ArrayBuffer) => void;
+  /** Flush interval in milliseconds. Default: 250. */
+  flushIntervalMs?: number;
+}
+
+export type CaptureStatus = "idle" | "starting" | "capturing" | "error";
+
+export interface UseAudioCaptureReturn {
+  status: CaptureStatus;
+  /** Actual sample rate of the AudioContext (e.g. 48000). */
+  sampleRate: number | null;
+  startCapture: () => Promise<void>;
+  stopCapture: () => void;
+}
+
+/**
+ * Hook that captures audio from the selected microphone, resamples to 16 kHz
+ * mono, encodes as PCM16, and delivers chunks via `onChunk` callback.
+ *
+ * Reads `selectedDeviceId` from the Zustand recording store (set by C1).
+ *
+ * Usage:
+ * ```tsx
+ * const { status, startCapture, stopCapture } = useAudioCapture({
+ *   onChunk: (pcm16) => websocket.send(pcm16),
+ * });
+ * ```
+ */
+export function useAudioCapture(
+  options: UseAudioCaptureOptions,
+): UseAudioCaptureReturn {
+  const { onChunk, flushIntervalMs = DEFAULT_FLUSH_INTERVAL_MS } = options;
+
+  const selectedDeviceId = useRecordingStore((s) => s.selectedDeviceId);
+
+  const [status, setStatus] = useState<CaptureStatus>("idle");
+  const [sampleRate, setSampleRate] = useState<number | null>(null);
+
+  // Mutable refs — audio callbacks fire at high frequency, no re-renders
+  const nodesRef = useRef<CaptureNodes | null>(null);
+  const bufferRef = useRef<Float32Array[]>([]);
+  const flushTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const onChunkRef = useRef(onChunk);
+  onChunkRef.current = onChunk;
+
+  /** Flush accumulated Float32 samples → resample → PCM16 → callback. */
+  const flush = useCallback(() => {
+    const chunks = bufferRef.current;
+    if (chunks.length === 0) return;
+    bufferRef.current = [];
+
+    const context = nodesRef.current?.context;
+    if (!context) return;
+
+    // Merge all buffered Float32 chunks into one contiguous array
+    let totalLength = 0;
+    for (const c of chunks) totalLength += c.length;
+    const merged = new Float32Array(totalLength);
+    let offset = 0;
+    for (const c of chunks) {
+      merged.set(c, offset);
+      offset += c.length;
+    }
+
+    const pcm16 = encodePcm16Chunk(merged, context.sampleRate);
+    onChunkRef.current(pcm16);
+  }, []);
+
+  const startCapture = useCallback(async () => {
+    if (nodesRef.current) return; // already capturing
+
+    setStatus("starting");
+    try {
+      const constraints: MediaStreamConstraints = {
+        audio: selectedDeviceId
+          ? { deviceId: { exact: selectedDeviceId } }
+          : true,
+      };
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+
+      const nodes = await createCaptureNodes(stream, (samples) => {
+        bufferRef.current.push(samples);
+      });
+
+      nodesRef.current = nodes;
+      setSampleRate(nodes.context.sampleRate);
+
+      // Start periodic flush
+      flushTimerRef.current = setInterval(flush, flushIntervalMs);
+
+      setStatus("capturing");
+    } catch {
+      setStatus("error");
+    }
+  }, [selectedDeviceId, flush, flushIntervalMs]);
+
+  const stopCapture = useCallback(() => {
+    // Flush remaining buffered samples
+    flush();
+
+    if (flushTimerRef.current) {
+      clearInterval(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+
+    nodesRef.current?.stop();
+    nodesRef.current = null;
+    bufferRef.current = [];
+
+    setSampleRate(null);
+    setStatus("idle");
+  }, [flush]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (flushTimerRef.current) clearInterval(flushTimerRef.current);
+      nodesRef.current?.stop();
+    };
+  }, []);
+
+  return { status, sampleRate, startCapture, stopCapture };
+}

--- a/frontend/src/lib/audio/audio-worklet-processor.ts
+++ b/frontend/src/lib/audio/audio-worklet-processor.ts
@@ -1,0 +1,80 @@
+/**
+ * Main-thread helper for the AudioWorklet-based capture pipeline.
+ *
+ * Handles worklet registration, AudioContext setup, and provides
+ * a ScriptProcessorNode fallback for browsers without AudioWorklet support.
+ */
+
+const WORKLET_URL = "/audio-capture-processor.js";
+const PROCESSOR_NAME = "audio-capture-processor";
+
+/** Callback invoked with raw Float32 audio chunks from the mic. */
+export type AudioChunkCallback = (samples: Float32Array) => void;
+
+export interface CaptureNodes {
+  context: AudioContext;
+  source: MediaStreamAudioSourceNode;
+  /** AudioWorkletNode when supported, null when using fallback. */
+  workletNode: AudioWorkletNode | null;
+  /** ScriptProcessorNode fallback, null when worklet is available. */
+  scriptNode: ScriptProcessorNode | null;
+  stream: MediaStream;
+  stop: () => void;
+}
+
+/**
+ * Set up the audio capture graph using AudioWorklet (preferred) with
+ * ScriptProcessorNode fallback.
+ *
+ * Returns handles needed to stop capture later.
+ */
+export async function createCaptureNodes(
+  stream: MediaStream,
+  onChunk: AudioChunkCallback,
+): Promise<CaptureNodes> {
+  const context = new AudioContext();
+  const source = context.createMediaStreamSource(stream);
+
+  let workletNode: AudioWorkletNode | null = null;
+  let scriptNode: ScriptProcessorNode | null = null;
+
+  const supportsWorklet = typeof AudioWorkletNode !== "undefined";
+
+  if (supportsWorklet) {
+    try {
+      await context.audioWorklet.addModule(WORKLET_URL);
+      workletNode = new AudioWorkletNode(context, PROCESSOR_NAME);
+      workletNode.port.onmessage = (e: MessageEvent<Float32Array>) => {
+        onChunk(e.data);
+      };
+      source.connect(workletNode);
+      // Worklet doesn't need to connect to destination (no playback)
+    } catch {
+      // Worklet registration failed — fall through to ScriptProcessor
+      workletNode = null;
+    }
+  }
+
+  if (!workletNode) {
+    // Fallback: ScriptProcessorNode (deprecated but widely supported)
+    const bufferSize = 4096;
+    scriptNode = context.createScriptProcessor(bufferSize, 1, 1);
+    scriptNode.onaudioprocess = (e: AudioProcessingEvent) => {
+      const input = e.inputBuffer.getChannelData(0);
+      onChunk(new Float32Array(input));
+    };
+    source.connect(scriptNode);
+    scriptNode.connect(context.destination);
+  }
+
+  const stop = () => {
+    workletNode?.port.postMessage("stop");
+    workletNode?.disconnect();
+    scriptNode?.disconnect();
+    source.disconnect();
+    stream.getTracks().forEach((t) => t.stop());
+    void context.close();
+  };
+
+  return { context, source, workletNode, scriptNode, stream, stop };
+}

--- a/frontend/src/lib/audio/pcm-encoder.ts
+++ b/frontend/src/lib/audio/pcm-encoder.ts
@@ -1,0 +1,66 @@
+/**
+ * Resample raw Float32 audio to 16 kHz mono and encode as PCM16 (Int16Array).
+ *
+ * The backend expects: PCM 16-bit signed, 16 000 Hz, mono — this module
+ * bridges the gap between the browser's native sample rate (typically 44.1/48 kHz)
+ * and that server format.
+ */
+
+/** Target sample rate expected by the VoiceVault backend. */
+export const TARGET_SAMPLE_RATE = 16_000;
+
+/**
+ * Downsample a Float32Array captured at `inputRate` to `TARGET_SAMPLE_RATE`
+ * using linear interpolation.
+ *
+ * Returns a new Float32Array at the target rate.
+ */
+export function resampleToTarget(
+  input: Float32Array,
+  inputRate: number,
+): Float32Array {
+  if (inputRate === TARGET_SAMPLE_RATE) return input;
+
+  const ratio = inputRate / TARGET_SAMPLE_RATE;
+  const outputLength = Math.ceil(input.length / ratio);
+  const output = new Float32Array(outputLength);
+
+  for (let i = 0; i < outputLength; i++) {
+    const srcIndex = i * ratio;
+    const lo = Math.floor(srcIndex);
+    const hi = Math.min(lo + 1, input.length - 1);
+    const frac = srcIndex - lo;
+    output[i] = (input[lo] ?? 0) * (1 - frac) + (input[hi] ?? 0) * frac;
+  }
+
+  return output;
+}
+
+/**
+ * Encode a Float32Array (values in -1..1) to PCM16 (Int16Array).
+ *
+ * Clamps values to prevent overflow distortion.
+ */
+export function float32ToPcm16(float32: Float32Array): Int16Array {
+  const pcm16 = new Int16Array(float32.length);
+  for (let i = 0; i < float32.length; i++) {
+    const clamped = Math.max(-1, Math.min(1, float32[i] ?? 0));
+    pcm16[i] = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+  }
+  return pcm16;
+}
+
+/**
+ * Full pipeline: resample + encode in one call.
+ *
+ * Takes raw Float32 audio at the browser's native rate and returns
+ * an ArrayBuffer of PCM16 at 16 kHz, ready to send over WebSocket.
+ */
+export function encodePcm16Chunk(
+  float32: Float32Array,
+  inputSampleRate: number,
+): ArrayBuffer {
+  const resampled = resampleToTarget(float32, inputSampleRate);
+  const pcm16 = float32ToPcm16(resampled);
+  return pcm16.buffer as ArrayBuffer;
+}

--- a/frontend/src/stores/recording.ts
+++ b/frontend/src/stores/recording.ts
@@ -1,19 +1,45 @@
 import { create } from "zustand";
 
+import type { CaptureStatus } from "@/hooks/useAudioCapture";
+
 interface RecordingState {
+  // ── C1: Device selection ──
+  selectedDeviceId: string | null;
+  setSelectedDeviceId: (deviceId: string | null) => void;
+
+  // ── Recording session ──
   isRecording: boolean;
   currentRecordingId: number | null;
-  selectedDeviceId: string | null;
   start: (id: number) => void;
   stop: () => void;
-  setSelectedDeviceId: (deviceId: string | null) => void;
+
+  // ── C2: Audio capture status ──
+  captureStatus: CaptureStatus;
+  sampleRate: number | null;
+  setCaptureStatus: (status: CaptureStatus) => void;
+  setSampleRate: (rate: number | null) => void;
 }
 
 export const useRecordingStore = create<RecordingState>((set) => ({
+  // ── C1 ──
+  selectedDeviceId: null,
+  setSelectedDeviceId: (deviceId) => set({ selectedDeviceId: deviceId }),
+
+  // ── Recording session ──
   isRecording: false,
   currentRecordingId: null,
-  selectedDeviceId: null,
   start: (id) => set({ isRecording: true, currentRecordingId: id }),
-  stop: () => set({ isRecording: false, currentRecordingId: null }),
-  setSelectedDeviceId: (deviceId) => set({ selectedDeviceId: deviceId }),
+  stop: () =>
+    set({
+      isRecording: false,
+      currentRecordingId: null,
+      captureStatus: "idle",
+      sampleRate: null,
+    }),
+
+  // ── C2 ──
+  captureStatus: "idle",
+  sampleRate: null,
+  setCaptureStatus: (captureStatus) => set({ captureStatus }),
+  setSampleRate: (sampleRate) => set({ sampleRate }),
 }));


### PR DESCRIPTION
## Summary
- **AudioWorklet processor** for low-latency mic capture on a dedicated audio thread, with ScriptProcessorNode fallback
- **PCM encoder** (`pcm-encoder.ts`): linear-interpolation resampling from native rate (44.1/48 kHz) → 16 kHz mono, then Float32 → PCM16 (Int16Array)
- **`useAudioCapture` hook**: manages Web Audio graph lifecycle, buffers samples, flushes PCM16 chunks at configurable intervals (default 250ms) via callback — ready for C3 WebSocket transport
- **Zustand store**: extended with `captureStatus` and `sampleRate` fields for downstream UI/state consumers

### Architecture

```
Microphone → getUserMedia(deviceId)
           → AudioContext.createMediaStreamSource()
           → AudioWorkletNode (audio thread)
             ├─ posts Float32 chunks → main thread
             └─ fallback: ScriptProcessorNode
           → Buffer accumulation (ref-based, no re-renders)
           → setInterval flush (250ms)
             → resampleToTarget(48kHz → 16kHz)
             → float32ToPcm16()
             → onChunk(ArrayBuffer) ← ready for WebSocket
```

### Files

| File | Purpose |
|------|---------|
| `frontend/public/audio-capture-processor.js` | AudioWorklet processor (loaded by audio thread) |
| `frontend/src/lib/audio/pcm-encoder.ts` | Resample + PCM16 encode utilities |
| `frontend/src/lib/audio/audio-worklet-processor.ts` | Main-thread AudioWorklet setup + fallback |
| `frontend/src/hooks/useAudioCapture.ts` | React hook: capture lifecycle + chunked buffer |
| `frontend/src/stores/recording.ts` | Zustand store: +captureStatus, +sampleRate |

## Test plan
- [ ] `pnpm type-check` passes (verified)
- [ ] `pnpm build` passes (verified)
- [ ] Manual: open `/recording`, grant mic permission, call `startCapture()` from devtools — verify `onChunk` receives ArrayBuffer chunks
- [ ] Manual: verify AudioWorklet path in Chrome; ScriptProcessor fallback in Safari (if applicable)
- [ ] Verify chunk size: ~4000 samples per 250ms flush at 16kHz

🤖 Generated with [Claude Code](https://claude.com/claude-code)