### PR TITLE
feat(frontend): add WebSocket protocol adapter with auto-reconnect (closes #82)

### DIFF
--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,0 +1,159 @@
+"use client";
+
+/**
+ * React hook that wraps `VoiceVaultWsClient` for the transcription WebSocket.
+ *
+ * Manages the client lifecycle (create → connect → disconnect on unmount),
+ * syncs connection state to the Zustand recording store, and exposes typed
+ * callbacks for each server message type.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+
+import { useRecordingStore } from "@/stores/recording";
+import {
+  VoiceVaultWsClient,
+  type WsClientOptions,
+} from "@/lib/websocket/ws-client";
+import type {
+  WsConnectionState,
+  WsErrorData,
+  WsMessage,
+  WsSummaryData,
+  WsTranscriptData,
+} from "@/types/ws-messages";
+
+// ---------------------------------------------------------------------------
+// Hook options
+// ---------------------------------------------------------------------------
+
+export interface UseWebSocketOptions {
+  /** Recording ID to connect to. `null` = don't connect. */
+  recordingId: number | null;
+  /** ISO language code (optional, e.g. "ko"). */
+  language?: string;
+  /** Auth token (optional, for WS_AUTH_ENABLED). */
+  token?: string;
+  /** Called on each real-time transcript segment. */
+  onTranscript?: (data: WsTranscriptData) => void;
+  /** Called on each 1-minute summary. */
+  onSummary?: (data: WsSummaryData) => void;
+  /** Called on server error messages. */
+  onError?: (data: WsErrorData) => void;
+  /** Called on any connection state change. */
+  onStateChange?: (state: WsConnectionState) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook return
+// ---------------------------------------------------------------------------
+
+export interface UseWebSocketReturn {
+  /** Current connection state (from Zustand store). */
+  connectionState: WsConnectionState;
+  /** Send a PCM16 audio chunk to the server. */
+  sendAudio: (pcm16: ArrayBuffer) => void;
+  /** Manually disconnect (also called on unmount). */
+  disconnect: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
+  const { recordingId, language, token } = options;
+
+  // Keep callbacks in refs so they don't cause reconnects on change
+  const onTranscriptRef = useRef(options.onTranscript);
+  const onSummaryRef = useRef(options.onSummary);
+  const onErrorRef = useRef(options.onError);
+  const onStateChangeRef = useRef(options.onStateChange);
+  onTranscriptRef.current = options.onTranscript;
+  onSummaryRef.current = options.onSummary;
+  onErrorRef.current = options.onError;
+  onStateChangeRef.current = options.onStateChange;
+
+  const clientRef = useRef<VoiceVaultWsClient | null>(null);
+
+  // Zustand store actions
+  const setWsState = useRecordingStore((s) => s.setWsState);
+
+  // ── Connect / disconnect lifecycle ──────────────────────────────────────
+
+  useEffect(() => {
+    if (recordingId === null) {
+      // No recording → ensure disconnected
+      clientRef.current?.disconnect();
+      clientRef.current = null;
+      setWsState("disconnected");
+      return;
+    }
+
+    const clientOpts: WsClientOptions = {
+      recordingId,
+      language,
+      token,
+    };
+
+    const client = new VoiceVaultWsClient(clientOpts);
+    clientRef.current = client;
+
+    // --- Subscribe to events ---
+
+    const unsubs: (() => void)[] = [];
+
+    unsubs.push(
+      client.on("stateChange", (state) => {
+        setWsState(state);
+        onStateChangeRef.current?.(state);
+      }),
+    );
+
+    unsubs.push(
+      client.on("message", (msg: WsMessage) => {
+        switch (msg.type) {
+          case "transcript":
+            onTranscriptRef.current?.(msg.data);
+            break;
+          case "summary":
+            onSummaryRef.current?.(msg.data);
+            break;
+          case "error":
+            onErrorRef.current?.(msg.data);
+            break;
+          // "connected" and "status" are handled internally by the client
+        }
+      }),
+    );
+
+    unsubs.push(
+      client.on("error", (err) => {
+        onErrorRef.current?.({ detail: err.message });
+      }),
+    );
+
+    client.connect();
+
+    return () => {
+      for (const unsub of unsubs) unsub();
+      client.disconnect();
+      clientRef.current = null;
+    };
+  }, [recordingId, language, token, setWsState]);
+
+  // ── Stable public API ───────────────────────────────────────────────────
+
+  const sendAudio = useCallback((pcm16: ArrayBuffer) => {
+    clientRef.current?.sendAudio(pcm16);
+  }, []);
+
+  const disconnect = useCallback(() => {
+    clientRef.current?.disconnect();
+    clientRef.current = null;
+  }, []);
+
+  const connectionState = useRecordingStore((s) => s.wsState);
+
+  return { connectionState, sendAudio, disconnect };
+}

--- a/frontend/src/lib/websocket/ws-client.ts
+++ b/frontend/src/lib/websocket/ws-client.ts
@@ -1,0 +1,285 @@
+/**
+ * Low-level WebSocket client for the VoiceVault transcription endpoint.
+ *
+ * Responsibilities:
+ * - Connect / disconnect lifecycle
+ * - Auto-reconnect with exponential backoff + jitter
+ * - Binary message sending (PCM16 audio chunks)
+ * - JSON message parsing with discriminated-union type safety
+ * - Connection state tracking via event listeners
+ *
+ * This module is framework-agnostic — React integration lives in
+ * `@/hooks/useWebSocket`.
+ */
+
+import type {
+  WsConnectionState,
+  WsMessage,
+  WsMessageType,
+} from "@/types/ws-messages";
+import { wsTranscribeUrl } from "@/lib/env";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface WsClientOptions {
+  /** Recording session ID (required for the WS URL). */
+  recordingId: number;
+  /** ISO language code for transcription (e.g. "ko", "en"). */
+  language?: string;
+  /** Authentication token (when WS_AUTH_ENABLED on backend). */
+  token?: string;
+  /** Base delay in ms for first reconnect attempt. Default: 1000. */
+  reconnectBaseDelay?: number;
+  /** Maximum delay in ms between reconnect attempts. Default: 30000. */
+  reconnectMaxDelay?: number;
+  /** Maximum number of reconnect attempts. 0 = unlimited. Default: 10. */
+  maxReconnectAttempts?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Event system
+// ---------------------------------------------------------------------------
+
+type WsEventMap = {
+  /** Fires on every connection state transition. */
+  stateChange: WsConnectionState;
+  /** Fires for each parsed JSON message from the server. */
+  message: WsMessage;
+  /** Fires when the connection is permanently closed (no more retries). */
+  close: { code: number; reason: string };
+  /** Fires on WebSocket or parse error. */
+  error: { message: string };
+};
+
+type WsEventName = keyof WsEventMap;
+type WsListener<K extends WsEventName> = (payload: WsEventMap[K]) => void;
+
+// ---------------------------------------------------------------------------
+// Valid message types for runtime validation
+// ---------------------------------------------------------------------------
+
+const VALID_MESSAGE_TYPES = new Set<WsMessageType>([
+  "connected",
+  "transcript",
+  "summary",
+  "status",
+  "error",
+]);
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+export class VoiceVaultWsClient {
+  // ── Config ──
+  private readonly recordingId: number;
+  private readonly language: string | undefined;
+  private readonly token: string | undefined;
+  private readonly baseDelay: number;
+  private readonly maxDelay: number;
+  private readonly maxAttempts: number;
+
+  // ── State ──
+  private ws: WebSocket | null = null;
+  private _state: WsConnectionState = "disconnected";
+  private reconnectAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  // ── Event listeners ──
+  private listeners = new Map<WsEventName, Set<WsListener<WsEventName>>>();
+
+  constructor(options: WsClientOptions) {
+    this.recordingId = options.recordingId;
+    this.language = options.language;
+    this.token = options.token;
+    this.baseDelay = options.reconnectBaseDelay ?? 1_000;
+    this.maxDelay = options.reconnectMaxDelay ?? 30_000;
+    this.maxAttempts = options.maxReconnectAttempts ?? 10;
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────
+
+  /** Current connection state (read-only). */
+  get state(): WsConnectionState {
+    return this._state;
+  }
+
+  /** Open the WebSocket connection. Safe to call multiple times. */
+  connect(): void {
+    if (this.disposed) return;
+    if (this.ws) return; // already connected / connecting
+
+    this.setState("connecting");
+    const url = this.buildUrl();
+    this.ws = new WebSocket(url);
+    this.ws.binaryType = "arraybuffer";
+
+    this.ws.onopen = this.handleOpen;
+    this.ws.onclose = this.handleClose;
+    this.ws.onerror = this.handleError;
+    this.ws.onmessage = this.handleMessage;
+  }
+
+  /** Gracefully close the connection. Stops reconnect attempts. */
+  disconnect(): void {
+    this.disposed = true;
+    this.clearReconnectTimer();
+    if (this.ws) {
+      this.ws.onclose = null; // prevent reconnect on intentional close
+      this.ws.close(1000, "Client disconnect");
+      this.ws = null;
+    }
+    this.setState("disconnected");
+  }
+
+  /** Send raw PCM16 audio bytes to the server. */
+  sendAudio(pcm16: ArrayBuffer): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(pcm16);
+    }
+  }
+
+  /** Subscribe to an event. Returns an unsubscribe function. */
+  on<K extends WsEventName>(
+    event: K,
+    listener: WsListener<K>,
+  ): () => void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    const set = this.listeners.get(event)!;
+    set.add(listener as WsListener<WsEventName>);
+    return () => {
+      set.delete(listener as WsListener<WsEventName>);
+    };
+  }
+
+  // ── Internal ────────────────────────────────────────────────────────────
+
+  private buildUrl(): string {
+    let url = wsTranscribeUrl(this.recordingId);
+    if (this.language) url += `&language=${encodeURIComponent(this.language)}`;
+    if (this.token) url += `&token=${encodeURIComponent(this.token)}`;
+    return url;
+  }
+
+  private setState(next: WsConnectionState): void {
+    if (this._state === next) return;
+    this._state = next;
+    this.emit("stateChange", next);
+  }
+
+  private handleOpen = (): void => {
+    this.reconnectAttempt = 0;
+    // State will transition to "connected" when we receive the "connected" message.
+    // This prevents a brief "connected" flash before the server confirms.
+  };
+
+  private handleClose = (ev: CloseEvent): void => {
+    this.ws = null;
+
+    if (this.disposed) {
+      this.setState("disconnected");
+      return;
+    }
+
+    // Attempt reconnect
+    if (this.maxAttempts > 0 && this.reconnectAttempt >= this.maxAttempts) {
+      this.setState("disconnected");
+      this.emit("close", { code: ev.code, reason: ev.reason });
+      return;
+    }
+
+    this.setState("reconnecting");
+    this.scheduleReconnect();
+  };
+
+  private handleError = (): void => {
+    this.emit("error", { message: "WebSocket connection error" });
+    // onclose will fire after onerror — reconnect logic lives there
+  };
+
+  private handleMessage = (ev: MessageEvent): void => {
+    if (typeof ev.data !== "string") return; // ignore unexpected binary
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(ev.data);
+    } catch {
+      this.emit("error", { message: "Failed to parse WebSocket message" });
+      return;
+    }
+
+    if (!this.isValidMessage(parsed)) {
+      this.emit("error", { message: `Unknown WS message type: ${JSON.stringify((parsed as Record<string, unknown>)?.type)}` });
+      return;
+    }
+
+    const msg = parsed as WsMessage;
+
+    // Transition to "connected" on handshake confirmation
+    if (msg.type === "connected") {
+      this.setState("connected");
+    }
+
+    this.emit("message", msg);
+  };
+
+  // ── Reconnect ───────────────────────────────────────────────────────────
+
+  private scheduleReconnect(): void {
+    this.clearReconnectTimer();
+
+    const delay = this.computeDelay();
+    this.reconnectAttempt++;
+
+    this.reconnectTimer = setTimeout(() => {
+      if (!this.disposed) {
+        this.connect();
+      }
+    }, delay);
+  }
+
+  /** Exponential backoff with ±25 % jitter. */
+  private computeDelay(): number {
+    const exponential = this.baseDelay * 2 ** this.reconnectAttempt;
+    const capped = Math.min(exponential, this.maxDelay);
+    const jitter = capped * (0.75 + Math.random() * 0.5); // 75%–125%
+    return Math.round(jitter);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  private isValidMessage(data: unknown): data is WsMessage {
+    if (typeof data !== "object" || data === null) return false;
+    const obj = data as Record<string, unknown>;
+    return (
+      typeof obj.type === "string" &&
+      VALID_MESSAGE_TYPES.has(obj.type as WsMessageType) &&
+      typeof obj.data === "object" &&
+      obj.data !== null
+    );
+  }
+
+  private emit<K extends WsEventName>(event: K, payload: WsEventMap[K]): void {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    for (const fn of set) {
+      try {
+        (fn as WsListener<K>)(payload);
+      } catch {
+        // Don't let a listener crash the client
+      }
+    }
+  }
+}

--- a/frontend/src/stores/recording.ts
+++ b/frontend/src/stores/recording.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 import type { CaptureStatus } from "@/hooks/useAudioCapture";
+import type { WsConnectionState } from "@/types/ws-messages";
 
 interface RecordingState {
   // ── C1: Device selection ──
@@ -18,6 +19,10 @@ interface RecordingState {
   sampleRate: number | null;
   setCaptureStatus: (status: CaptureStatus) => void;
   setSampleRate: (rate: number | null) => void;
+
+  // ── C3: WebSocket connection status ──
+  wsState: WsConnectionState;
+  setWsState: (state: WsConnectionState) => void;
 }
 
 export const useRecordingStore = create<RecordingState>((set) => ({
@@ -35,6 +40,7 @@ export const useRecordingStore = create<RecordingState>((set) => ({
       currentRecordingId: null,
       captureStatus: "idle",
       sampleRate: null,
+      wsState: "disconnected",
     }),
 
   // ── C2 ──
@@ -42,4 +48,8 @@ export const useRecordingStore = create<RecordingState>((set) => ({
   sampleRate: null,
   setCaptureStatus: (captureStatus) => set({ captureStatus }),
   setSampleRate: (sampleRate) => set({ sampleRate }),
+
+  // ── C3 ──
+  wsState: "disconnected",
+  setWsState: (wsState) => set({ wsState }),
 }));

--- a/frontend/src/types/ws-messages.ts
+++ b/frontend/src/types/ws-messages.ts
@@ -1,0 +1,78 @@
+/**
+ * TypeScript types for the VoiceVault WebSocket message protocol.
+ *
+ * Mirrors backend `WebSocketMessage` / `WebSocketMessageType` from
+ * `backend/src/core/models.py`. The server sends JSON messages with a
+ * discriminator `type` field; each variant carries a typed `data` payload.
+ *
+ * Client → Server: raw PCM16 bytes (binary frames, not JSON).
+ */
+
+// ---------------------------------------------------------------------------
+// Message type discriminator
+// ---------------------------------------------------------------------------
+
+export type WsMessageType =
+  | "connected"
+  | "transcript"
+  | "summary"
+  | "status"
+  | "error";
+
+// ---------------------------------------------------------------------------
+// Per-type data payloads
+// ---------------------------------------------------------------------------
+
+/** Initial handshake — confirms the server accepted the connection. */
+export interface WsConnectedData {
+  recording_id: number;
+}
+
+/** Real-time STT text segment from faster-whisper. */
+export interface WsTranscriptData {
+  text: string;
+  confidence?: number;
+  language?: string;
+}
+
+/** 1-minute summary produced by the orchestrator. */
+export interface WsSummaryData {
+  minute_index: number;
+  summary_text: string;
+  keywords?: string[];
+  speakers?: string[];
+  confidence?: number;
+  model_used?: string;
+}
+
+/** Recording state change (e.g. processing → completed). */
+export interface WsStatusData {
+  status: string;
+  detail?: string;
+}
+
+/** Error during transcription or summarization. */
+export interface WsErrorData {
+  detail: string;
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union of all server→client messages
+// ---------------------------------------------------------------------------
+
+export type WsMessage =
+  | { type: "connected"; data: WsConnectedData }
+  | { type: "transcript"; data: WsTranscriptData }
+  | { type: "summary"; data: WsSummaryData }
+  | { type: "status"; data: WsStatusData }
+  | { type: "error"; data: WsErrorData };
+
+// ---------------------------------------------------------------------------
+// Connection state
+// ---------------------------------------------------------------------------
+
+export type WsConnectionState =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "reconnecting";


### PR DESCRIPTION
## Summary
- **`ws-messages.ts`**: TypeScript discriminated union types mirroring backend `WebSocketMessage` protocol (connected/transcript/summary/status/error)
- **`ws-client.ts`**: Framework-agnostic WebSocket client with connect/disconnect lifecycle, exponential backoff reconnect with jitter, binary PCM16 sending, and typed JSON message parsing
- **`useWebSocket.ts`**: React hook bridging `VoiceVaultWsClient` ↔ component lifecycle with typed callbacks per message type
- **Zustand store**: Added `wsState` / `setWsState` slice to recording store for reactive connection status across components

## Architecture

```
useWebSocket(recordingId)
  ├─ creates VoiceVaultWsClient → WebSocket connection
  ├─ subscribes to stateChange → Zustand store.wsState
  ├─ routes messages → onTranscript / onSummary / onError callbacks
  └─ cleanup on unmount / recordingId change → disconnect
```

**Reconnect strategy**: exponential backoff (1s base, 30s cap, 10 max attempts) with ±25% jitter to avoid thundering herd on server recovery.

## Test plan
- [ ] Verify `pnpm type-check` passes (✅ confirmed locally)
- [ ] Verify `pnpm build` passes (✅ confirmed locally)
- [ ] Manual: connect to backend WS endpoint, verify `connected` handshake
- [ ] Manual: disconnect network → verify auto-reconnect with backoff
- [ ] Manual: send PCM16 chunks → verify transcript/summary messages received

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)