### PR TITLE
feat(frontend): recording state machine + realtime transcript (closes #83)

### DIFF
--- a/frontend/src/app/recording/page.tsx
+++ b/frontend/src/app/recording/page.tsx
@@ -1,40 +1,190 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useMicrophonePermission } from "@/hooks/use-microphone-permission";
 import { useMediaDevices } from "@/hooks/use-media-devices";
+import { useAudioCapture } from "@/hooks/useAudioCapture";
+import { useWebSocket } from "@/hooks/useWebSocket";
 import { useRecordingStore } from "@/stores/recording";
+import { recordingsApi } from "@/lib/api/recordings";
+import type { WsErrorData } from "@/types/ws-messages";
+
 import { PermissionGate } from "@/components/recording/PermissionGate";
 import { DeviceSelector } from "@/components/recording/DeviceSelector";
+import { RecordingControls } from "@/components/recording/RecordingControls";
+import { RecordingStatus } from "@/components/recording/RecordingStatus";
+import { TranscriptView } from "@/components/recording/TranscriptView";
 
 export default function RecordingPage() {
-  const { status, request } = useMicrophonePermission();
+  // ── C1: Microphone permission & device selection ──
+  const { status: permStatus, request: requestPermission } = useMicrophonePermission();
   const { devices, selectedDeviceId, selectDevice, refresh } = useMediaDevices(
-    status === "granted",
+    permStatus === "granted",
   );
 
-  const setSelectedDeviceId = useRecordingStore((s) => s.setSelectedDeviceId);
+  // ── Global store selectors ──
+  const phase = useRecordingStore((s) => s.phase);
+  const currentRecordingId = useRecordingStore((s) => s.currentRecordingId);
+  const captureStatus = useRecordingStore((s) => s.captureStatus);
+  const wsState = useRecordingStore((s) => s.wsState);
+  const startedAt = useRecordingStore((s) => s.startedAt);
+  const errorMessage = useRecordingStore((s) => s.errorMessage);
+  const transcripts = useRecordingStore((s) => s.transcripts);
+  const summaries = useRecordingStore((s) => s.summaries);
 
-  // Sync local device selection to global store
+  const setSelectedDeviceId = useRecordingStore((s) => s.setSelectedDeviceId);
+  const requestStart = useRecordingStore((s) => s.requestStart);
+  const confirmRecording = useRecordingStore((s) => s.confirmRecording);
+  const requestStop = useRecordingStore((s) => s.requestStop);
+  const confirmStopped = useRecordingStore((s) => s.confirmStopped);
+  const setError = useRecordingStore((s) => s.setError);
+  const reset = useRecordingStore((s) => s.reset);
+  const addTranscript = useRecordingStore((s) => s.addTranscript);
+  const addSummary = useRecordingStore((s) => s.addSummary);
+
+  // Sync device selection to store
+  const handleDeviceSelect = useCallback(
+    (deviceId: string) => {
+      selectDevice(deviceId);
+      setSelectedDeviceId(deviceId);
+    },
+    [selectDevice, setSelectedDeviceId],
+  );
+
+  // Ref for sendAudio so the onChunk callback stays stable
+  const sendAudioRef = useRef<(pcm16: ArrayBuffer) => void>(() => {});
+
+  // ── C2: Audio capture — sends PCM16 chunks to WS ──
+  const { startCapture, stopCapture } = useAudioCapture({
+    onChunk: useCallback(
+      (pcm16: ArrayBuffer) => sendAudioRef.current(pcm16),
+      [],
+    ),
+  });
+
+  // ── C3: WebSocket — reactive on currentRecordingId ──
+  const { sendAudio, disconnect: disconnectWs } = useWebSocket({
+    recordingId: phase === "recording" || phase === "requesting" ? currentRecordingId : null,
+    onTranscript: addTranscript,
+    onSummary: addSummary,
+    onError: useCallback(
+      (data: WsErrorData) => {
+        // WS errors during recording → log but don't halt
+        if (useRecordingStore.getState().phase === "recording") {
+          console.error("[WS error]", data.detail);
+        }
+      },
+      [],
+    ),
+  });
+
   useEffect(() => {
-    setSelectedDeviceId(selectedDeviceId);
-  }, [selectedDeviceId, setSelectedDeviceId]);
+    sendAudioRef.current = sendAudio;
+  });
+
+  // ── Orchestration: Start recording ──
+  const handleStart = useCallback(async () => {
+    requestStart();
+
+    try {
+      // 1. Create recording on backend
+      const recording = await recordingsApi.create();
+
+      // 2. Transition to recording (sets currentRecordingId → WS auto-connects)
+      confirmRecording(recording.id);
+
+      // 3. Start audio capture
+      await startCapture();
+    } catch (err) {
+      // Clean up on failure
+      stopCapture();
+      disconnectWs();
+      setError(err instanceof Error ? err.message : "Failed to start recording");
+    }
+  }, [requestStart, confirmRecording, startCapture, stopCapture, disconnectWs, setError]);
+
+  // ── Orchestration: Stop recording ──
+  const handleStop = useCallback(async () => {
+    requestStop();
+
+    try {
+      // 1. Stop audio capture first (flush remaining chunks)
+      stopCapture();
+
+      // 2. Disconnect WebSocket
+      disconnectWs();
+
+      // 3. Tell backend to stop
+      const recId = useRecordingStore.getState().currentRecordingId;
+      if (recId !== null) {
+        await recordingsApi.stop(recId);
+      }
+
+      confirmStopped();
+    } catch (err) {
+      // Stop failed — force cleanup
+      stopCapture();
+      disconnectWs();
+      setError(err instanceof Error ? err.message : "Failed to stop recording");
+    }
+  }, [requestStop, stopCapture, disconnectWs, confirmStopped, setError]);
+
+  // ── Orchestration: Reset ──
+  const handleReset = useCallback(() => {
+    stopCapture();
+    disconnectWs();
+    reset();
+  }, [stopCapture, disconnectWs, reset]);
+
+  // ── Render ──
+  const isRecording = phase === "recording";
+  const showTranscript = phase === "recording" || phase === "stopping" || phase === "stopped";
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <h1 className="text-3xl font-bold">Recording</h1>
 
-      <PermissionGate status={status} onRequest={request}>
-        <div className="w-full max-w-md space-y-6">
-          <DeviceSelector
-            devices={devices}
-            selectedDeviceId={selectedDeviceId}
-            onSelect={selectDevice}
-            onRefresh={refresh}
+      <PermissionGate status={permStatus} onRequest={requestPermission}>
+        <div className="w-full max-w-lg space-y-6">
+          {/* Device selector — hidden during active recording */}
+          {phase !== "recording" && phase !== "stopping" && (
+            <DeviceSelector
+              devices={devices}
+              selectedDeviceId={selectedDeviceId}
+              onSelect={handleDeviceSelect}
+              onRefresh={refresh}
+            />
+          )}
+
+          {/* Status display */}
+          <RecordingStatus
+            phase={phase}
+            captureStatus={captureStatus}
+            wsState={wsState}
+            startedAt={startedAt}
+            errorMessage={errorMessage}
+            transcriptCount={transcripts.length}
+            summaryCount={summaries.length}
           />
-          <p className="text-center text-sm text-zinc-500">
-            Microphone ready. Recording controls coming soon.
-          </p>
+
+          {/* Start / Stop / Reset button */}
+          <div className="flex justify-center">
+            <RecordingControls
+              phase={phase}
+              onStart={handleStart}
+              onStop={handleStop}
+              onReset={handleReset}
+            />
+          </div>
+
+          {/* Live transcript */}
+          {showTranscript && (
+            <TranscriptView
+              transcripts={transcripts}
+              summaries={summaries}
+              isRecording={isRecording}
+            />
+          )}
         </div>
       </PermissionGate>
     </div>

--- a/frontend/src/components/recording/RecordingControls.tsx
+++ b/frontend/src/components/recording/RecordingControls.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import type { RecordingPhase } from "@/stores/recording";
+import { Button } from "@/components/ui/Button";
+import { Spinner } from "@/components/ui/Spinner";
+
+interface RecordingControlsProps {
+  phase: RecordingPhase;
+  onStart: () => void;
+  onStop: () => void;
+  onReset: () => void;
+}
+
+export function RecordingControls({
+  phase,
+  onStart,
+  onStop,
+  onReset,
+}: RecordingControlsProps) {
+  switch (phase) {
+    case "idle":
+      return (
+        <Button size="lg" onClick={onStart} className="gap-2">
+          <RecordIcon />
+          Start Recording
+        </Button>
+      );
+
+    case "requesting":
+      return (
+        <Button size="lg" disabled className="gap-2">
+          <Spinner size="sm" />
+          Starting…
+        </Button>
+      );
+
+    case "recording":
+      return (
+        <Button
+          size="lg"
+          variant="secondary"
+          onClick={onStop}
+          className="gap-2 border-red-300 text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
+        >
+          <StopIcon />
+          Stop Recording
+        </Button>
+      );
+
+    case "stopping":
+      return (
+        <Button size="lg" variant="secondary" disabled className="gap-2">
+          <Spinner size="sm" />
+          Stopping…
+        </Button>
+      );
+
+    case "stopped":
+      return (
+        <Button size="lg" onClick={onReset} className="gap-2">
+          <RecordIcon />
+          New Recording
+        </Button>
+      );
+
+    case "error":
+      return (
+        <Button size="lg" onClick={onReset} className="gap-2">
+          <RecordIcon />
+          Try Again
+        </Button>
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+
+function RecordIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="h-5 w-5"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="8" />
+    </svg>
+  );
+}
+
+function StopIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="h-5 w-5"
+      aria-hidden="true"
+    >
+      <rect x="6" y="6" width="12" height="12" rx="1" />
+    </svg>
+  );
+}

--- a/frontend/src/components/recording/RecordingStatus.tsx
+++ b/frontend/src/components/recording/RecordingStatus.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { RecordingPhase } from "@/stores/recording";
+import type { CaptureStatus } from "@/hooks/useAudioCapture";
+import type { WsConnectionState } from "@/types/ws-messages";
+import { cn } from "@/lib/cn";
+
+interface RecordingStatusProps {
+  phase: RecordingPhase;
+  captureStatus: CaptureStatus;
+  wsState: WsConnectionState;
+  startedAt: number | null;
+  errorMessage: string | null;
+  transcriptCount: number;
+  summaryCount: number;
+  className?: string;
+}
+
+export function RecordingStatus({
+  phase,
+  captureStatus,
+  wsState,
+  startedAt,
+  errorMessage,
+  transcriptCount,
+  summaryCount,
+  className,
+}: RecordingStatusProps) {
+  const elapsed = useElapsedTime(phase === "recording" ? startedAt : null);
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      {/* Duration display */}
+      {(phase === "recording" || phase === "stopping") && (
+        <div className="text-center">
+          <span className="font-mono text-4xl font-bold tabular-nums text-zinc-900 dark:text-zinc-100">
+            {formatDuration(elapsed)}
+          </span>
+        </div>
+      )}
+
+      {/* Status badges */}
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <StatusBadge
+          label={phaseLabel(phase)}
+          color={phaseColor(phase)}
+        />
+
+        {phase === "recording" && (
+          <>
+            <StatusBadge
+              label={captureLabel(captureStatus)}
+              color={captureStatus === "capturing" ? "green" : "zinc"}
+            />
+            <StatusBadge
+              label={wsLabel(wsState)}
+              color={wsColor(wsState)}
+            />
+          </>
+        )}
+      </div>
+
+      {/* Counts */}
+      {(transcriptCount > 0 || summaryCount > 0) && (
+        <div className="flex items-center justify-center gap-4 text-xs text-zinc-500">
+          {transcriptCount > 0 && (
+            <span>{transcriptCount} segment{transcriptCount !== 1 ? "s" : ""}</span>
+          )}
+          {summaryCount > 0 && (
+            <span>{summaryCount} summar{summaryCount !== 1 ? "ies" : "y"}</span>
+          )}
+        </div>
+      )}
+
+      {/* Error message */}
+      {phase === "error" && errorMessage && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StatusBadge
+// ---------------------------------------------------------------------------
+
+type BadgeColor = "green" | "red" | "yellow" | "blue" | "zinc";
+
+const colorStyles: Record<BadgeColor, string> = {
+  green: "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-400",
+  red: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400",
+  yellow: "bg-yellow-100 text-yellow-700 dark:bg-yellow-950 dark:text-yellow-400",
+  blue: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-400",
+  zinc: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400",
+};
+
+function StatusBadge({ label, color }: { label: string; color: BadgeColor }) {
+  return (
+    <span className={cn("rounded-full px-2.5 py-0.5 text-xs font-medium", colorStyles[color])}>
+      {label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Label / color helpers
+// ---------------------------------------------------------------------------
+
+function phaseLabel(phase: RecordingPhase): string {
+  switch (phase) {
+    case "idle": return "Ready";
+    case "requesting": return "Starting…";
+    case "recording": return "Recording";
+    case "stopping": return "Stopping…";
+    case "stopped": return "Stopped";
+    case "error": return "Error";
+  }
+}
+
+function phaseColor(phase: RecordingPhase): BadgeColor {
+  switch (phase) {
+    case "idle": return "zinc";
+    case "requesting": return "yellow";
+    case "recording": return "red";
+    case "stopping": return "yellow";
+    case "stopped": return "blue";
+    case "error": return "red";
+  }
+}
+
+function captureLabel(status: CaptureStatus): string {
+  switch (status) {
+    case "idle": return "Mic idle";
+    case "starting": return "Mic starting…";
+    case "capturing": return "Mic active";
+    case "error": return "Mic error";
+  }
+}
+
+function wsLabel(state: WsConnectionState): string {
+  switch (state) {
+    case "disconnected": return "WS off";
+    case "connecting": return "WS connecting…";
+    case "connected": return "WS connected";
+    case "reconnecting": return "WS reconnecting…";
+  }
+}
+
+function wsColor(state: WsConnectionState): BadgeColor {
+  switch (state) {
+    case "disconnected": return "zinc";
+    case "connecting": return "yellow";
+    case "connected": return "green";
+    case "reconnecting": return "yellow";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Elapsed time hook
+// ---------------------------------------------------------------------------
+
+function useElapsedTime(startedAt: number | null): number {
+  const calcElapsed = useCallback(
+    () => (startedAt === null ? 0 : Math.floor((Date.now() - startedAt) / 1000)),
+    [startedAt],
+  );
+
+  const [elapsed, setElapsed] = useState(calcElapsed);
+
+  useEffect(() => {
+    // Recalculate immediately when startedAt changes (via interval callback)
+    const tick = () => setElapsed(calcElapsed());
+
+    // First tick right away in an interval callback (not synchronous in effect body)
+    const immediate = setTimeout(tick, 0);
+    const timer = setInterval(tick, 1000);
+
+    return () => {
+      clearTimeout(immediate);
+      clearInterval(timer);
+    };
+  }, [calcElapsed]);
+
+  return elapsed;
+}
+
+// ---------------------------------------------------------------------------
+// Format duration as HH:MM:SS
+// ---------------------------------------------------------------------------
+
+function formatDuration(totalSeconds: number): string {
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+
+  const pad = (n: number) => n.toString().padStart(2, "0");
+
+  return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+}

--- a/frontend/src/components/recording/TranscriptView.tsx
+++ b/frontend/src/components/recording/TranscriptView.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { TranscriptEntry, SummaryEntry } from "@/stores/recording";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/Card";
+import { cn } from "@/lib/cn";
+
+interface TranscriptViewProps {
+  transcripts: TranscriptEntry[];
+  summaries: SummaryEntry[];
+  isRecording: boolean;
+  className?: string;
+}
+
+/** Threshold (px) for auto-scroll: if within this distance of bottom, keep scrolling. */
+const AUTO_SCROLL_THRESHOLD = 80;
+
+export function TranscriptView({
+  transcripts,
+  summaries,
+  isRecording,
+  className,
+}: TranscriptViewProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const shouldAutoScroll = useRef(true);
+
+  // Track whether user has scrolled away from bottom
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    shouldAutoScroll.current = distanceFromBottom < AUTO_SCROLL_THRESHOLD;
+  };
+
+  // Auto-scroll when new transcripts arrive
+  useEffect(() => {
+    if (shouldAutoScroll.current && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [transcripts.length]);
+
+  const isEmpty = transcripts.length === 0 && summaries.length === 0;
+
+  return (
+    <Card className={cn("flex flex-col", className)}>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Live Transcript</CardTitle>
+        {isRecording && (
+          <span className="flex items-center gap-1.5 text-xs font-medium text-red-500">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-red-500" />
+            LIVE
+          </span>
+        )}
+      </CardHeader>
+
+      <CardContent className="flex-1">
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className="max-h-80 min-h-[200px] overflow-y-auto"
+        >
+          {isEmpty && (
+            <p className="py-8 text-center text-sm text-zinc-400">
+              {isRecording
+                ? "Waiting for speech…"
+                : "Transcripts will appear here during recording."}
+            </p>
+          )}
+
+          {/* Summaries */}
+          {summaries.length > 0 && (
+            <div className="mb-4 space-y-2">
+              {summaries.map((s) => (
+                <div
+                  key={`summary-${s.minuteIndex}`}
+                  className="rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-900 dark:bg-blue-950"
+                >
+                  <div className="mb-1 flex items-center gap-2">
+                    <span className="text-xs font-semibold text-blue-600 dark:text-blue-400">
+                      Minute {s.minuteIndex + 1} Summary
+                    </span>
+                    {s.keywords && s.keywords.length > 0 && (
+                      <div className="flex gap-1">
+                        {s.keywords.slice(0, 3).map((kw) => (
+                          <span
+                            key={kw}
+                            className="rounded-full bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+                          >
+                            {kw}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <p className="text-sm text-blue-900 dark:text-blue-100">
+                    {s.summaryText}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Transcript entries */}
+          {transcripts.length > 0 && (
+            <div className="space-y-1">
+              {transcripts.map((t) => (
+                <p key={t.id} className="text-sm leading-relaxed text-zinc-700 dark:text-zinc-300">
+                  {t.text}
+                  {t.confidence != null && t.confidence < 0.5 && (
+                    <span className="ml-1 text-xs text-zinc-400" title={`Confidence: ${Math.round(t.confidence * 100)}%`}>
+                      (?)
+                    </span>
+                  )}
+                </p>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/stores/recording.ts
+++ b/frontend/src/stores/recording.ts
@@ -1,18 +1,82 @@
 import { create } from "zustand";
 
 import type { CaptureStatus } from "@/hooks/useAudioCapture";
-import type { WsConnectionState } from "@/types/ws-messages";
+import type { WsConnectionState, WsTranscriptData, WsSummaryData } from "@/types/ws-messages";
+
+// ---------------------------------------------------------------------------
+// Recording phase state machine
+// ---------------------------------------------------------------------------
+
+/**
+ * Recording lifecycle phases:
+ *
+ *   idle → requesting → recording → stopping → stopped
+ *                 ↘        ↘           ↘
+ *                       error ←←←←←←←←←
+ *
+ * - idle:       No active session. Ready to start.
+ * - requesting: POST /recordings sent, awaiting API + audio + WS setup.
+ * - recording:  Audio capture active, WS connected, transcripts flowing.
+ * - stopping:   Stop requested, tearing down capture + WS + PATCH /stop.
+ * - stopped:    Session complete. Transcripts preserved for review.
+ * - error:      Something failed. `errorMessage` has details.
+ */
+export type RecordingPhase =
+  | "idle"
+  | "requesting"
+  | "recording"
+  | "stopping"
+  | "stopped"
+  | "error";
+
+// ---------------------------------------------------------------------------
+// Transcript entry
+// ---------------------------------------------------------------------------
+
+export interface TranscriptEntry {
+  id: number;
+  text: string;
+  confidence?: number;
+  language?: string;
+  timestamp: number; // Date.now() when received
+}
+
+// ---------------------------------------------------------------------------
+// Summary entry
+// ---------------------------------------------------------------------------
+
+export interface SummaryEntry {
+  minuteIndex: number;
+  summaryText: string;
+  keywords?: string[];
+  speakers?: string[];
+  confidence?: number;
+  modelUsed?: string;
+  timestamp: number;
+}
+
+// ---------------------------------------------------------------------------
+// Store interface
+// ---------------------------------------------------------------------------
 
 interface RecordingState {
   // ── C1: Device selection ──
   selectedDeviceId: string | null;
   setSelectedDeviceId: (deviceId: string | null) => void;
 
-  // ── Recording session ──
-  isRecording: boolean;
+  // ── C4: Recording phase state machine ──
+  phase: RecordingPhase;
   currentRecordingId: number | null;
-  start: (id: number) => void;
-  stop: () => void;
+  errorMessage: string | null;
+  startedAt: number | null; // Date.now() when recording started
+
+  // Phase transitions
+  requestStart: () => void;
+  confirmRecording: (recordingId: number) => void;
+  requestStop: () => void;
+  confirmStopped: () => void;
+  setError: (message: string) => void;
+  reset: () => void;
 
   // ── C2: Audio capture status ──
   captureStatus: CaptureStatus;
@@ -23,24 +87,79 @@ interface RecordingState {
   // ── C3: WebSocket connection status ──
   wsState: WsConnectionState;
   setWsState: (state: WsConnectionState) => void;
+
+  // ── C4: Transcript & summary accumulation ──
+  transcripts: TranscriptEntry[];
+  summaries: SummaryEntry[];
+  addTranscript: (data: WsTranscriptData) => void;
+  addSummary: (data: WsSummaryData) => void;
 }
+
+// ---------------------------------------------------------------------------
+// Auto-increment ID for transcript entries
+// ---------------------------------------------------------------------------
+
+let nextTranscriptId = 0;
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
 
 export const useRecordingStore = create<RecordingState>((set) => ({
   // ── C1 ──
   selectedDeviceId: null,
   setSelectedDeviceId: (deviceId) => set({ selectedDeviceId: deviceId }),
 
-  // ── Recording session ──
-  isRecording: false,
+  // ── C4: State machine ──
+  phase: "idle",
   currentRecordingId: null,
-  start: (id) => set({ isRecording: true, currentRecordingId: id }),
-  stop: () =>
+  errorMessage: null,
+  startedAt: null,
+
+  requestStart: () =>
+    set({ phase: "requesting", errorMessage: null }),
+
+  confirmRecording: (recordingId) =>
     set({
-      isRecording: false,
-      currentRecordingId: null,
+      phase: "recording",
+      currentRecordingId: recordingId,
+      startedAt: Date.now(),
+      errorMessage: null,
+      transcripts: [],
+      summaries: [],
+    }),
+
+  requestStop: () =>
+    set({ phase: "stopping" }),
+
+  confirmStopped: () =>
+    set({
+      phase: "stopped",
       captureStatus: "idle",
       sampleRate: null,
       wsState: "disconnected",
+    }),
+
+  setError: (message) =>
+    set({
+      phase: "error",
+      errorMessage: message,
+      captureStatus: "idle",
+      sampleRate: null,
+      wsState: "disconnected",
+    }),
+
+  reset: () =>
+    set({
+      phase: "idle",
+      currentRecordingId: null,
+      errorMessage: null,
+      startedAt: null,
+      captureStatus: "idle",
+      sampleRate: null,
+      wsState: "disconnected",
+      transcripts: [],
+      summaries: [],
     }),
 
   // ── C2 ──
@@ -52,4 +171,38 @@ export const useRecordingStore = create<RecordingState>((set) => ({
   // ── C3 ──
   wsState: "disconnected",
   setWsState: (wsState) => set({ wsState }),
+
+  // ── C4: Transcript & summary accumulation ──
+  transcripts: [],
+  summaries: [],
+
+  addTranscript: (data) =>
+    set((state) => ({
+      transcripts: [
+        ...state.transcripts,
+        {
+          id: nextTranscriptId++,
+          text: data.text,
+          confidence: data.confidence,
+          language: data.language,
+          timestamp: Date.now(),
+        },
+      ],
+    })),
+
+  addSummary: (data) =>
+    set((state) => ({
+      summaries: [
+        ...state.summaries,
+        {
+          minuteIndex: data.minute_index,
+          summaryText: data.summary_text,
+          keywords: data.keywords,
+          speakers: data.speakers,
+          confidence: data.confidence,
+          modelUsed: data.model_used,
+          timestamp: Date.now(),
+        },
+      ],
+    })),
 }));


### PR DESCRIPTION
## Summary
- Add recording page state machine (idle → requesting → recording → stopping → stopped)
- Add RecordingControls, RecordingStatus, and TranscriptView components
- Wire up Zustand recording store with phase transitions
- Fix missing `useCallback` import in RecordingStatus

## Test plan
- [ ] Verify `pnpm --dir frontend build` passes
- [ ] Manual test: recording page renders without errors
- [ ] Verify state transitions work correctly in UI

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)