### PR TITLE
feat(frontend): add summaries page API integration (closes #84)

### DIFF
--- a/frontend/src/app/summaries/page.tsx
+++ b/frontend/src/app/summaries/page.tsx
@@ -1,8 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { Spinner } from "@/components/ui/Spinner";
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent } from "@/components/ui/Card";
+import { SummaryList } from "@/components/summaries/SummaryList";
+import { useRecordings } from "@/hooks/useRecordings";
+import { ApiError } from "@/lib/api-client";
+import type { RecordingResponse, RecordingStatus } from "@/types/api";
+
+const STATUS_LABELS: Record<RecordingStatus, string> = {
+  active: "Active",
+  processing: "Processing",
+  completed: "Completed",
+  failed: "Failed",
+  imported: "Imported",
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+function formatDuration(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
 export default function SummariesPage() {
+  const [statusFilter, setStatusFilter] = useState<
+    RecordingStatus | undefined
+  >();
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const { data: recordings, isLoading, error, refetch } = useRecordings({
+    status: statusFilter,
+    sort: "newest",
+  });
+
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-8">
-      <h1 className="text-3xl font-bold">Summaries</h1>
-      <p className="mt-4 text-zinc-500">Summaries page — coming soon.</p>
+    <div className="mx-auto max-w-6xl space-y-6 p-6">
+      <h1 className="text-2xl font-bold">Summaries</h1>
+
+      {/* Status filter */}
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant={statusFilter === undefined ? "primary" : "secondary"}
+          size="sm"
+          onClick={() => setStatusFilter(undefined)}
+        >
+          All
+        </Button>
+        {(
+          Object.entries(STATUS_LABELS) as [RecordingStatus, string][]
+        ).map(([value, label]) => (
+          <Button
+            key={value}
+            variant={statusFilter === value ? "primary" : "secondary"}
+            size="sm"
+            onClick={() => setStatusFilter(value)}
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="flex items-center justify-center py-16">
+          <Spinner size="lg" />
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-400">
+          <p className="font-medium">Failed to load recordings</p>
+          <p className="mt-1">
+            {error instanceof ApiError
+              ? error.message
+              : "An unexpected error occurred."}
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="mt-3"
+            onClick={() => refetch()}
+          >
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {/* Empty */}
+      {recordings && recordings.length === 0 && (
+        <p className="py-16 text-center text-zinc-400">
+          No recordings found. Start a recording to see summaries here.
+        </p>
+      )}
+
+      {/* Recordings list */}
+      {recordings && recordings.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-3">
+          {/* Sidebar: recording list */}
+          <div className="space-y-2 md:col-span-1">
+            {recordings.map((rec: RecordingResponse) => (
+              <button
+                key={rec.id}
+                type="button"
+                onClick={() => setSelectedId(rec.id)}
+                className={`w-full rounded-lg border p-3 text-left text-sm transition-colors ${
+                  selectedId === rec.id
+                    ? "border-zinc-900 bg-zinc-50 dark:border-zinc-100 dark:bg-zinc-900"
+                    : "border-zinc-200 hover:border-zinc-300 dark:border-zinc-800 dark:hover:border-zinc-700"
+                }`}
+              >
+                <p className="font-medium">
+                  {rec.title ?? `Recording #${rec.id}`}
+                </p>
+                <div className="mt-1 flex items-center gap-2 text-xs text-zinc-400">
+                  <span>{formatDate(rec.started_at)}</span>
+                  <span>&middot;</span>
+                  <span>{formatDuration(rec.total_minutes)}</span>
+                  <span>&middot;</span>
+                  <span className="capitalize">{rec.status}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {/* Main: summaries panel */}
+          <div className="md:col-span-2">
+            {selectedId === null ? (
+              <Card>
+                <CardContent className="py-12 text-center text-zinc-400">
+                  Select a recording to view its summaries.
+                </CardContent>
+              </Card>
+            ) : (
+              <SummaryList recordingId={selectedId} />
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/summaries/SummaryCard.tsx
+++ b/frontend/src/components/summaries/SummaryCard.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/Card";
+import type { SummaryResponse, HourSummaryResponse } from "@/types/api";
+
+// ---------------------------------------------------------------------------
+// Minute summary card
+// ---------------------------------------------------------------------------
+
+interface MinuteSummaryCardProps {
+  summary: SummaryResponse;
+}
+
+export function MinuteSummaryCard({ summary }: MinuteSummaryCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span>Minute {summary.minute_index + 1}</span>
+          {summary.confidence > 0 && (
+            <span className="text-xs font-normal text-zinc-400">
+              {Math.round(summary.confidence * 100)}%
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="whitespace-pre-wrap">{summary.summary_text}</p>
+        {summary.keywords && summary.keywords.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {summary.keywords.map((kw) => (
+              <span
+                key={kw}
+                className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+              >
+                {kw}
+              </span>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hour summary card
+// ---------------------------------------------------------------------------
+
+interface HourSummaryCardProps {
+  summary: HourSummaryResponse;
+}
+
+export function HourSummaryCard({ summary }: HourSummaryCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span>Hour {summary.hour_index + 1}</span>
+          <span className="text-xs font-normal text-zinc-400">
+            {summary.token_count} tokens
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="whitespace-pre-wrap">{summary.summary_text}</p>
+        {summary.keywords && summary.keywords.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {summary.keywords.map((kw) => (
+              <span
+                key={kw}
+                className="rounded-full bg-blue-50 px-2 py-0.5 text-xs text-blue-600 dark:bg-blue-950 dark:text-blue-400"
+              >
+                {kw}
+              </span>
+            ))}
+          </div>
+        )}
+        {summary.model_used && (
+          <p className="mt-2 text-xs text-zinc-400">
+            Model: {summary.model_used}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/summaries/SummaryList.tsx
+++ b/frontend/src/components/summaries/SummaryList.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { Spinner } from "@/components/ui/Spinner";
+import { Button } from "@/components/ui/Button";
+import { MinuteSummaryCard, HourSummaryCard } from "./SummaryCard";
+import { useMinuteSummaries, useHourSummaries } from "@/hooks/useSummaries";
+import { ApiError } from "@/lib/api-client";
+
+type Tab = "minute" | "hour";
+
+interface SummaryListProps {
+  recordingId: number;
+}
+
+export function SummaryList({ recordingId }: SummaryListProps) {
+  const [tab, setTab] = useState<Tab>("minute");
+
+  const minute = useMinuteSummaries(recordingId);
+  const hour = useHourSummaries(recordingId);
+
+  const active = tab === "minute" ? minute : hour;
+
+  return (
+    <div className="space-y-4">
+      {/* Tab bar */}
+      <div className="flex gap-2">
+        <Button
+          variant={tab === "minute" ? "primary" : "secondary"}
+          size="sm"
+          onClick={() => setTab("minute")}
+        >
+          Minute summaries
+        </Button>
+        <Button
+          variant={tab === "hour" ? "primary" : "secondary"}
+          size="sm"
+          onClick={() => setTab("hour")}
+        >
+          Hour summaries
+        </Button>
+      </div>
+
+      {/* Loading */}
+      {active.isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      )}
+
+      {/* Error */}
+      {active.error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-400">
+          <p className="font-medium">Failed to load summaries</p>
+          <p className="mt-1">
+            {active.error instanceof ApiError
+              ? active.error.message
+              : "An unexpected error occurred."}
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="mt-3"
+            onClick={() => active.refetch()}
+          >
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {/* Empty */}
+      {active.data && active.data.length === 0 && (
+        <p className="py-8 text-center text-sm text-zinc-400">
+          No {tab} summaries yet for this recording.
+        </p>
+      )}
+
+      {/* Cards */}
+      {tab === "minute" && minute.data && minute.data.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {minute.data.map((s) => (
+            <MinuteSummaryCard key={s.id} summary={s} />
+          ))}
+        </div>
+      )}
+
+      {tab === "hour" && hour.data && hour.data.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-1 lg:grid-cols-2">
+          {hour.data.map((s) => (
+            <HourSummaryCard key={s.id} summary={s} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useRecordings.ts
+++ b/frontend/src/hooks/useRecordings.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { recordingsApi } from "@/lib/api/recordings";
+import type { RecordingResponse, RecordingStatus } from "@/types/api";
+
+export const recordingsQueryKey = ["recordings"] as const;
+
+export function useRecordings(filters?: {
+  status?: RecordingStatus;
+  sort?: "newest" | "oldest";
+}) {
+  return useQuery({
+    queryKey: [...recordingsQueryKey, filters],
+    queryFn: async () => {
+      const data = await recordingsApi.list();
+      return applyFilters(data, filters);
+    },
+  });
+}
+
+export function useRecording(id: number | null) {
+  return useQuery({
+    queryKey: [...recordingsQueryKey, id],
+    queryFn: () => recordingsApi.get(id!),
+    enabled: id !== null,
+  });
+}
+
+function applyFilters(
+  recordings: RecordingResponse[],
+  filters?: { status?: RecordingStatus; sort?: "newest" | "oldest" },
+): RecordingResponse[] {
+  let result = recordings;
+
+  if (filters?.status) {
+    result = result.filter((r) => r.status === filters.status);
+  }
+
+  const direction = filters?.sort ?? "newest";
+  result = [...result].sort((a, b) => {
+    const diff =
+      new Date(b.started_at).getTime() - new Date(a.started_at).getTime();
+    return direction === "newest" ? diff : -diff;
+  });
+
+  return result;
+}

--- a/frontend/src/hooks/useSummaries.ts
+++ b/frontend/src/hooks/useSummaries.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { summariesApi } from "@/lib/api/summaries";
+
+export function useMinuteSummaries(recordingId: number | null) {
+  return useQuery({
+    queryKey: ["summaries", "minute", recordingId],
+    queryFn: () => summariesApi.list(recordingId!),
+    enabled: recordingId !== null,
+  });
+}
+
+export function useHourSummaries(recordingId: number | null) {
+  return useQuery({
+    queryKey: ["summaries", "hour", recordingId],
+    queryFn: () => summariesApi.hourSummaries(recordingId!),
+    enabled: recordingId !== null,
+  });
+}


### PR DESCRIPTION
## Summary
- **React Query hooks**: `useRecordings` (recordings list with status filter + sort) and `useSummaries` (minute/hour summaries with dependent query pattern)
- **Summary components**: `MinuteSummaryCard`, `HourSummaryCard`, `SummaryList` (tabbed minute/hour view)
- **Summaries page**: master-detail layout — recording sidebar with status filter buttons + summary panel with loading/error/empty states

## Test plan
- [ ] `pnpm type-check` passes (verified)
- [ ] `pnpm build` passes (verified)
- [ ] Status filter buttons correctly toggle between All / Active / Processing / Completed / Failed / Imported
- [ ] Selecting a recording loads its minute summaries by default
- [ ] Switching to "Hour summaries" tab fetches and displays hour-level summaries
- [ ] Empty state shows when no recordings exist or no summaries for a recording
- [ ] Error state shows with retry button when API is unreachable
- [ ] Loading spinner shows while data is being fetched

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)