### PR TITLE
feat(frontend): add summaries tab UI with loading/empty/error states (closes #85)

### DIFF
--- a/frontend/src/app/summaries/page.tsx
+++ b/frontend/src/app/summaries/page.tsx
@@ -4,9 +4,10 @@ import { useState } from "react";
 import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent } from "@/components/ui/Card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { SummaryList } from "@/components/summaries/SummaryList";
 import { useRecordings } from "@/hooks/useRecordings";
-import { ApiError } from "@/lib/api-client";
 import type { RecordingResponse, RecordingStatus } from "@/types/api";
 
 const STATUS_LABELS: Record<RecordingStatus, string> = {
@@ -75,29 +76,36 @@ export default function SummariesPage() {
 
       {/* Error */}
       {error && (
-        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-400">
-          <p className="font-medium">Failed to load recordings</p>
-          <p className="mt-1">
-            {error instanceof ApiError
-              ? error.message
-              : "An unexpected error occurred."}
-          </p>
-          <Button
-            variant="secondary"
-            size="sm"
-            className="mt-3"
-            onClick={() => refetch()}
-          >
-            Retry
-          </Button>
-        </div>
+        <ErrorState
+          title="Failed to load recordings"
+          error={error}
+          onRetry={() => refetch()}
+        />
       )}
 
       {/* Empty */}
       {recordings && recordings.length === 0 && (
-        <p className="py-16 text-center text-zinc-400">
-          No recordings found. Start a recording to see summaries here.
-        </p>
+        <EmptyState
+          icon={
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-10 w-10"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="m12 8 4 4-4 4" />
+              <path d="M8 12h8" />
+            </svg>
+          }
+          title="No recordings found"
+          description="Start a recording to see summaries here."
+        />
       )}
 
       {/* Recordings list */}

--- a/frontend/src/components/summaries/SummaryTabs.tsx
+++ b/frontend/src/components/summaries/SummaryTabs.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { type KeyboardEvent, type ReactNode, useId, useRef } from "react";
+import { cn } from "@/lib/cn";
+
+export type SummaryTab = "minute" | "hour";
+
+interface TabConfig {
+  value: SummaryTab;
+  label: string;
+  count?: number;
+}
+
+interface SummaryTabsProps {
+  value: SummaryTab;
+  onChange: (tab: SummaryTab) => void;
+  minuteCount?: number;
+  hourCount?: number;
+  children: ReactNode;
+}
+
+const TABS: TabConfig[] = [
+  { value: "minute", label: "Minute summaries" },
+  { value: "hour", label: "Hour summaries" },
+];
+
+export function SummaryTabs({
+  value,
+  onChange,
+  minuteCount,
+  hourCount,
+  children,
+}: SummaryTabsProps) {
+  const id = useId();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const counts: Record<SummaryTab, number | undefined> = {
+    minute: minuteCount,
+    hour: hourCount,
+  };
+
+  function handleKeyDown(e: KeyboardEvent, index: number) {
+    let next: number;
+
+    switch (e.key) {
+      case "ArrowRight":
+        next = (index + 1) % TABS.length;
+        break;
+      case "ArrowLeft":
+        next = (index - 1 + TABS.length) % TABS.length;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = TABS.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    e.preventDefault();
+    const tab = TABS[next];
+    if (tab) {
+      onChange(tab.value);
+      tabRefs.current[next]?.focus();
+    }
+  }
+
+  return (
+    <div>
+      <div
+        role="tablist"
+        aria-label="Summary type"
+        className="flex gap-1 border-b border-zinc-200 dark:border-zinc-800"
+      >
+        {TABS.map((tab, i) => {
+          const isActive = value === tab.value;
+          const count = counts[tab.value];
+          return (
+            <button
+              key={tab.value}
+              ref={(el) => {
+                tabRefs.current[i] = el;
+              }}
+              id={`${id}-tab-${tab.value}`}
+              role="tab"
+              type="button"
+              aria-selected={isActive}
+              aria-controls={`${id}-panel-${tab.value}`}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => onChange(tab.value)}
+              onKeyDown={(e) => handleKeyDown(e, i)}
+              className={cn(
+                "-mb-px px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2",
+                isActive
+                  ? "border-b-2 border-zinc-900 text-zinc-900 dark:border-zinc-100 dark:text-zinc-100"
+                  : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300",
+              )}
+            >
+              {tab.label}
+              {count !== undefined && (
+                <span
+                  className={cn(
+                    "ml-2 inline-flex min-w-[1.25rem] items-center justify-center rounded-full px-1.5 py-0.5 text-xs",
+                    isActive
+                      ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                      : "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400",
+                  )}
+                >
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        id={`${id}-panel-${value}`}
+        role="tabpanel"
+        aria-labelledby={`${id}-tab-${value}`}
+        tabIndex={0}
+        className="pt-4"
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+interface EmptyStateProps {
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center py-12 text-center",
+        className,
+      )}
+    >
+      {icon && (
+        <div className="mb-3 text-zinc-300 dark:text-zinc-600">{icon}</div>
+      )}
+      <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
+        {title}
+      </p>
+      {description && (
+        <p className="mt-1 max-w-sm text-sm text-zinc-400 dark:text-zinc-500">
+          {description}
+        </p>
+      )}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/ErrorState.tsx
+++ b/frontend/src/components/ui/ErrorState.tsx
@@ -1,0 +1,40 @@
+import { Button } from "@/components/ui/Button";
+import { ApiError } from "@/lib/api-client";
+import { cn } from "@/lib/cn";
+
+interface ErrorStateProps {
+  title?: string;
+  error: unknown;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function ErrorState({
+  title = "Something went wrong",
+  error,
+  onRetry,
+  className,
+}: ErrorStateProps) {
+  const message =
+    error instanceof ApiError
+      ? error.message
+      : "An unexpected error occurred.";
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-400",
+        className,
+      )}
+    >
+      <p className="font-medium">{title}</p>
+      <p className="mt-1">{message}</p>
+      {onRetry && (
+        <Button variant="secondary" size="sm" className="mt-3" onClick={onRetry}>
+          Retry
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@/lib/cn";
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export function Skeleton({ className }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "animate-pulse rounded-lg bg-zinc-200 dark:bg-zinc-800",
+        className,
+      )}
+    />
+  );
+}
+
+/**
+ * Mimics a SummaryCard shape for loading states.
+ * Renders a card-shaped skeleton with title line, body lines, and keyword pills.
+ */
+export function SummaryCardSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-950"
+    >
+      {/* Title row */}
+      <div className="mb-4 flex items-center justify-between">
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-4 w-10" />
+      </div>
+      {/* Body lines */}
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-4/6" />
+      </div>
+      {/* Keyword pills */}
+      <div className="mt-3 flex gap-1.5">
+        <Skeleton className="h-5 w-14 rounded-full" />
+        <Skeleton className="h-5 w-10 rounded-full" />
+        <Skeleton className="h-5 w-16 rounded-full" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add **SummaryTabs** component with WAI-ARIA compliant tab pattern (arrow key navigation, `role="tablist"`/`role="tab"`/`role="tabpanel"`, badge counts)
- Add reusable **Skeleton** (with `SummaryCardSkeleton`), **EmptyState** (icon + title + description), and **ErrorState** (error message + retry button) UI primitives
- Refactor **SummaryList** to compose these new components instead of inline conditionals
- Update **SummariesPage** to use `ErrorState`/`EmptyState` for consistent UX across the app

## Test plan
- [ ] Verify minute/hour tabs switch correctly and show badge counts
- [ ] Verify keyboard navigation: Arrow Left/Right, Home/End between tabs
- [ ] Verify skeleton loading state renders card-shaped placeholders during fetch
- [ ] Verify empty state renders icon + message when no summaries exist
- [ ] Verify error state renders message + retry button on API failure
- [ ] `pnpm type-check` passes
- [ ] `pnpm build` passes

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)