### PR TITLE
chore(infra): unified dev orchestration (Makefile + docker-compose) (closes #95)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,9 @@ CORS_ORIGINS=["http://localhost:8501","http://localhost:3000"]
 DATABASE_URL=sqlite:///data/voicevault.db
 RECORDINGS_DIR=data/recordings
 EXPORTS_DIR=data/exports
+
+# --- Frontend (Next.js) ---
+# These are also in frontend/.env.local for local dev.
+# In Docker, they are set as build args in docker-compose.yml.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api/v1
+NEXT_PUBLIC_WS_URL=ws://localhost:8000

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,91 @@
-.PHONY: build up down logs health seed clean up-ollama dev-api dev-ui gen-openapi gen-types lint test
+.PHONY: dev dev-backend dev-frontend test test-backend test-frontend \
+       lint lint-backend lint-frontend gen-openapi gen-types setup \
+       build up down logs health seed clean up-ollama
 
-# ── Docker ──────────────────────────────────────────
+# ── Concurrent Development ─────────────────────
+
+# Run backend + frontend concurrently (Ctrl-C stops both)
+dev:
+	@echo "🚀 Starting backend (port 8000) + frontend (port 3000)..."
+	@trap 'kill 0' INT TERM; \
+	  $(MAKE) dev-backend & \
+	  $(MAKE) dev-frontend & \
+	  wait
+
+# Start backend API locally (PYTHONPATH=backend)
+dev-backend:
+	PYTHONPATH=backend uvicorn src.api.app:app --reload --port 8000
+
+# Start Next.js frontend locally
+dev-frontend:
+	cd frontend && pnpm dev
+
+# ── Testing ────────────────────────────────────
+
+# Run all tests (backend + frontend)
+test: test-backend test-frontend
+
+# Run backend tests (pytest)
+test-backend:
+	cd backend && pytest tests/ -v
+
+# Run frontend tests (vitest)
+test-frontend:
+	cd frontend && pnpm test
+
+# ── Linting ────────────────────────────────────
+
+# Lint all code (backend + frontend)
+lint: lint-backend lint-frontend
+
+# Lint backend (ruff check + format check)
+lint-backend:
+	ruff check backend/src/ backend/tests/
+	ruff format --check backend/src/ backend/tests/
+
+# Lint frontend (eslint + prettier + tsc)
+lint-frontend:
+	cd frontend && pnpm lint
+	cd frontend && pnpm format:check
+	cd frontend && pnpm type-check
+
+# ── Code Generation ────────────────────────────
+
+# Export OpenAPI schema to docs/openapi.json
+gen-openapi:
+	PYTHONPATH=backend python backend/scripts/export_openapi.py
+
+# Generate TypeScript types from OpenAPI spec
+gen-types:
+	cd frontend && pnpm gen:types
+
+# ── Setup ──────────────────────────────────────
+
+# Full project setup (backend venv + frontend deps + whisper model)
+setup:
+	@echo "📦 Setting up backend..."
+	cd backend && uv venv --python 3.12
+	cd backend && uv pip install -r requirements.txt
+	cd backend && uv pip install -e ".[dev]"
+	@echo "📦 Setting up frontend..."
+	cd frontend && pnpm install
+	@echo "📦 Downloading Whisper model..."
+	PYTHONPATH=backend python backend/scripts/download_models.py
+	@echo "📦 Seeding default templates..."
+	PYTHONPATH=backend python backend/scripts/seed_templates.py
+	@echo "✅ Setup complete! Run 'make dev' to start developing."
+
+# ── Docker ─────────────────────────────────────
 
 # Build all Docker images
 build:
 	docker compose build
 
-# Start API + UI (without Ollama — use LLM_PROVIDER=claude or external Ollama)
+# Start all services (backend + frontend, without Ollama)
 up:
 	docker compose up -d
 
-# Start API + UI + Ollama
+# Start all services + Ollama
 up-ollama:
 	docker compose --profile ollama up -d
 
@@ -24,46 +99,15 @@ logs:
 
 # Check health of running services
 health:
-	@echo "=== API Health ==="
+	@echo "=== Backend API ==="
 	@curl -sf http://localhost:8000/health | python3 -m json.tool || echo "API not healthy"
-	@echo "\n=== Streamlit UI ==="
-	@curl -sf -o /dev/null -w "HTTP %{http_code}" http://localhost:8501 && echo " OK" || echo "UI not reachable"
+	@echo "\n=== Frontend ==="
+	@curl -sf -o /dev/null -w "HTTP %{http_code}" http://localhost:3000 && echo " OK" || echo "Frontend not reachable"
 
 # Run demo data seeder inside the API container
 seed:
-	docker compose exec api python backend/scripts/seed_demo_data.py
+	docker compose exec backend python backend/scripts/seed_demo_data.py
 
 # Stop all services and remove volumes
 clean:
 	docker compose --profile ollama down -v
-
-# ── Local Development ───────────────────────────────
-
-# Start backend API locally (PYTHONPATH=backend)
-dev-api:
-	PYTHONPATH=backend uvicorn src.api.app:app --reload --port 8000
-
-# Start Streamlit UI locally
-dev-ui:
-	streamlit run src/ui/app.py
-
-# ── Code Generation ────────────────────────────────
-
-# Export OpenAPI schema to docs/openapi.json
-gen-openapi:
-	PYTHONPATH=backend python backend/scripts/export_openapi.py
-
-# Generate TypeScript types from OpenAPI spec
-gen-types:
-	cd frontend && pnpm gen:types
-
-# ── Quality ─────────────────────────────────────────
-
-# Lint & format check (backend code)
-lint:
-	ruff check backend/src/ backend/tests/
-	ruff format --check backend/src/ backend/tests/
-
-# Run tests (from backend/ directory)
-test:
-	cd backend && pytest tests/ -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
   # FastAPI Backend
-  api:
+  backend:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: voicevault-api
+    container_name: voicevault-backend
     ports:
       - "8000:8000"
     env_file: .env
@@ -47,28 +47,24 @@ services:
     command: uvicorn src.api.app:app --host 0.0.0.0 --port 8000 --reload
     restart: unless-stopped
 
-  # Streamlit Frontend
-  ui:
+  # Next.js Frontend
+  frontend:
     build:
-      context: .
+      context: ./frontend
       dockerfile: Dockerfile
-    container_name: voicevault-ui
+      args:
+        NEXT_PUBLIC_API_BASE_URL: http://backend:8000/api/v1
+        NEXT_PUBLIC_WS_URL: ws://backend:8000
+    container_name: voicevault-frontend
     ports:
-      - "8501:8501"
+      - "3000:3000"
     environment:
-      - API_BASE_URL=http://api:8000
-      - STREAMLIT_SERVER_PORT=8501
-      - STREAMLIT_SERVER_ADDRESS=0.0.0.0
-      - STREAMLIT_SERVER_HEADLESS=true
-      - STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
-    volumes:
-      - ./src/ui:/app/src/ui:ro
+      - NODE_ENV=production
     depends_on:
-      api:
+      backend:
         condition: service_healthy
     networks:
       - voicevault
-    command: streamlit run src/ui/app.py --server.port 8501 --server.address 0.0.0.0
     restart: unless-stopped
 
   # Ollama LLM Server (optional — start with: docker compose --profile ollama up)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,52 @@
+# Multi-stage Dockerfile for VoiceVault Next.js frontend
+# Uses standalone output for minimal production image (~150MB)
+
+# =============================================================================
+# Stage 1: Dependencies
+# =============================================================================
+FROM node:22-alpine AS deps
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# =============================================================================
+# Stage 2: Builder
+# =============================================================================
+FROM node:22-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Build-time env vars (NEXT_PUBLIC_* are inlined at build time)
+ARG NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api/v1
+ARG NEXT_PUBLIC_WS_URL=ws://localhost:8000
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
+
+RUN pnpm build
+
+# =============================================================================
+# Stage 3: Runner
+# =============================================================================
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy standalone build output
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- **Makefile**: Unified targets — `make dev` (concurrent backend+frontend), `make test` (pytest+vitest), `make lint` (ruff+eslint+prettier+tsc), `make gen-types`, `make setup` (full init)
- **docker-compose.yml**: Replaced Streamlit `ui` service with Next.js `frontend` service (port 3000, `depends_on: backend`), renamed `api` → `backend` for consistency
- **frontend/Dockerfile**: Multi-stage build (deps → builder → runner) with `output: "standalone"` for minimal production image
- **.env.example**: Added `NEXT_PUBLIC_API_BASE_URL` and `NEXT_PUBLIC_WS_URL` frontend variables

## Test plan
- [x] `make -n dev` / `test` / `lint` / `setup` — dry-run all targets parse correctly
- [x] `docker compose config --quiet` — validates docker-compose.yml syntax
- [x] `pnpm type-check` — frontend still compiles after `next.config.ts` change
- [ ] `make dev` — manually verify both servers start concurrently (port 8000 + 3000)
- [ ] `docker compose up` — verify full stack builds and frontend connects to backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)